### PR TITLE
When a namespace is selected, then the namespace link at the top of the

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -490,6 +490,15 @@ const AppDrawer = withStyles(styles)(function({ classes, variant, open, onClose,
 	// }
 	];
 
+	if( namespace ) {
+		var topitems = [{
+			"text": currentns, // "Namespaces", 
+			"path": "/namespaces/" + currentns, // "/namespaces", 
+			"icon": <AppsIcon/>, 
+			"selected": true
+		}];
+	}
+
 	/*
 	 * I have this idea of showing per type specifics here
 	 */


### PR DESCRIPTION
navigation menu should link to the root view of that namespace. This way we have an easy way to navigate to the root dashboard view.