### PR TITLE
Build docker images with branch name intact.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,10 @@ set -ex
 # LOCAL_REGISTRY="${LOCAL_REGISTRY:-registry.dev.appgoto.com}"
 LOCAL_REGISTRY="${LOCAL_REGISTRY:-buildregistry.localdomain}"
 
+GIT_BRNCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_SHA=$(git rev-parse HEAD | cut -c 1-8)
 
-IMAGE="${LOCAL_REGISTRY}/gfs-app:latest-$GIT_SHA"
+IMAGE="${LOCAL_REGISTRY}/gfs-app:${GIT_BRNCH}-${GIT_SHA}"
 LATEST_IMAGE="${LOCAL_REGISTRY}/gfs-app:latest"
 
 docker build -t $IMAGE -f Dockerfile.app.production .

--- a/buildui.sh
+++ b/buildui.sh
@@ -5,9 +5,10 @@ set -ex
 # LOCAL_REGISTRY="${LOCAL_REGISTRY:-registry.dev.appgoto.com}"
 LOCAL_REGISTRY="${LOCAL_REGISTRY:-buildregistry.localdomain}"
 
+GIT_BRNCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_SHA=$(git rev-parse HEAD | cut -c 1-8)
 
-IMAGE="${LOCAL_REGISTRY}/gfs-app:latest-$GIT_SHA"
+IMAGE="${LOCAL_REGISTRY}/gfs-app:${GIT_BRNCH}-${GIT_SHA}"
 LATEST_IMAGE="${LOCAL_REGISTRY}/gfs-app:latest"
 
 docker build -t $IMAGE -f Dockerfile.app.production .


### PR DESCRIPTION
Build docker images with branch name intact. This way we don't need special dev build scripts, as we can simply check out a dev branch and built it and the image would be tagged as such.