### PR TITLE
Work on showing instance dependencies in instance view.

### DIFF
--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -196,7 +196,8 @@ class Instance extends Component {
 			typename, 
 			type, 
 			instance, 
-			schema
+			schema, 
+			showdeps
 		} = this.props;
 
 		const { classes } = this.props;
@@ -229,7 +230,7 @@ class Instance extends Component {
 						schema, 
 						instance
 					)} />
-				{ instance && dependencies && dependencies.map(function(item) {
+				{ showdeps && instance && dependencies && dependencies.map(function(item) {
 					if(item && item.cardinality == "multiple") {
 						var deptypename = schema["properties"][item.name]["items"]["$ref"].replace("#/definitions/", "");
 						var deptype = schema["definitions"][deptypename];
@@ -243,7 +244,7 @@ class Instance extends Component {
 								typename={ deptypename } 
 								type={ deptype } 
 								schema={ depschema } 
-								/>
+								showdeps={false} />
 							</>
 					} else if(item && item.value) {
 						var deptypename = schema["properties"][item.name]["$ref"].replace("#/definitions/", "");
@@ -260,7 +261,7 @@ class Instance extends Component {
 								schema={ depschema } 
 								instanceid={item && item.value && item.value["_id"]} 
 								instance={item && item.value} 
-								/>
+								showdeps={false} />
 							</>
 					}
 				})}

--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -240,13 +240,21 @@ class Instance extends Component {
 							type={ item && item.type } />
 							</>
 					} else {
+						var deptypename = schema["properties"][item.name]["$ref"].replace("#/definitions/", "");
+						var deptype = schema["definitions"][deptypename];
+						var depschema = schema["definitions"][deptypename];
+						depschema["definitions"] = schema["definitions"];
 						return <> 
 							<InstanceView 
-							title={ item && item["_name"] } 
-							description={ item && item.type + " " + "(" + item.cardinality + ")" } 
-							namespace={namespace} 
-							typename={ item && item.type } 
-							type={ item && item.type } />
+								title={ item && item["name"] } 
+								description={ item && item.type + " " + "(" + item.cardinality + ")" } 
+								namespace={namespace} 
+								typename={ deptypename } 
+								type={ deptype } 
+								schema={ depschema } 
+								instanceid={item && item.value && item.value["_id"]} 
+								instance={item && item.value} 
+								/>
 							</>
 					}
 				})}

--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -230,7 +230,7 @@ class Instance extends Component {
 						instance
 					)} />
 				{ instance && dependencies && dependencies.map(function(item) {
-					if(item.cardinality == "multiple") {
+					if(item && item.cardinality == "multiple") {
 						var deptypename = schema["properties"][item.name]["items"]["$ref"].replace("#/definitions/", "");
 						var deptype = schema["definitions"][deptypename];
 						var depschema = schema["definitions"][deptypename];
@@ -245,7 +245,7 @@ class Instance extends Component {
 								schema={ depschema } 
 								/>
 							</>
-					} else {
+					} else if(item && item.value) {
 						var deptypename = schema["properties"][item.name]["$ref"].replace("#/definitions/", "");
 						var deptype = schema["definitions"][deptypename];
 						var depschema = schema["definitions"][deptypename];

--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -231,13 +231,19 @@ class Instance extends Component {
 					)} />
 				{ instance && dependencies && dependencies.map(function(item) {
 					if(item.cardinality == "multiple") {
+						var deptypename = schema["properties"][item.name]["items"]["$ref"].replace("#/definitions/", "");
+						var deptype = schema["definitions"][deptypename];
+						var depschema = schema["definitions"][deptypename];
+						depschema["definitions"] = schema["definitions"];
 						return <>
 							<InstancesView 
-							title={ item && item["_name"] } 
+								title={ item && item["name"] } 
 							description={ item && item.type + " " + "(" + item.cardinality + ")" } 
 							namespace={namespace} 
-							typename={ item && item.type } 
-							type={ item && item.type } />
+								typename={ deptypename } 
+								type={ deptype } 
+								schema={ depschema } 
+								/>
 							</>
 					} else {
 						var deptypename = schema["properties"][item.name]["$ref"].replace("#/definitions/", "");

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -336,7 +336,8 @@ class RootInstance extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
-						editable={false} />
+						editable={false} 
+						showdeps={true} />
 				</Grid>
 
 				<Grid 
@@ -355,7 +356,7 @@ class RootInstance extends Component {
 						schema={schema["entity"]} 
 						instanceid={instanceid} 
 						instance={instance} 
-						/>
+						showdeps={true} />
 				</Grid>
 			</Grid>
 			</Container>

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -338,7 +338,8 @@ class RootInstances extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
-						editable={true}/>
+						editable={true} 
+						showdeps={true} /> 
 				</Grid>
 			</Grid>
 			<SpeedDial


### PR DESCRIPTION
- The instance view should show single valued dependencies correctly.
- The instance view should show multi valued dependencies correctly.
- When processing dependencies in the instance view, first make sure
that the dependency field is valid.
- When processing dependencies in the instance view, use a deps flag to
indicate wether or not to process dependencies of dependencies, or
else we run into infinite loops of data loading.