### PR TITLE
Refacting data url for instances.

### DIFF
--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -57,6 +57,12 @@ class Instance extends Component {
 
 	}
 
+	getDataURL(namespace, typename, type, schema) {
+		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
+		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+		return dataurl;
+	}
+
 	getProperties(namespace, typename, type, schema, instance) {
 
 		var properties = [];
@@ -218,6 +224,13 @@ class Instance extends Component {
 			instance
 		);
 
+		var dataurl = this.getDataURL(
+			namespace, 
+			typename, 
+			type, 
+			schema
+		);
+
 		return (
 			<>
 				<DetailView 
@@ -244,6 +257,7 @@ class Instance extends Component {
 								typename={ deptypename } 
 								type={ deptype } 
 								schema={ depschema } 
+								dataurl={dataurl} 
 								showdeps={false} />
 							</>
 					} else if(item && item.value) {

--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -57,9 +57,10 @@ class Instance extends Component {
 
 	}
 
-	getDataURL(namespace, typename, type, schema) {
+	getDataURL(namespace, typename, type, schema, instance, instancefield) {
 		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+		// var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename + "/" + instance["_id"] + "/" + instancefield;
 		return dataurl;
 	}
 
@@ -224,12 +225,12 @@ class Instance extends Component {
 			instance
 		);
 
-		var dataurl = this.getDataURL(
-			namespace, 
-			typename, 
-			type, 
-			schema
-		);
+		// var dataurl = this.getDataURL(
+		// 	namespace, 
+		// 	typename, 
+		// 	type, 
+		// 	schema
+		// );
 
 		return (
 			<>
@@ -257,7 +258,14 @@ class Instance extends Component {
 								typename={ deptypename } 
 								type={ deptype } 
 								schema={ depschema } 
-								dataurl={dataurl} 
+								dataurl={_this.getDataURL(
+									namespace, 
+									typename, // deptypename, 
+									type, // deptype, 
+									schema, // depschema, 
+									instance, // item && item.value, 
+									item && item["name"]
+								)} 
 								showdeps={false} />
 							</>
 					} else if(item && item.value) {

--- a/src/components/Instances.js
+++ b/src/components/Instances.js
@@ -133,11 +133,11 @@ class Instances extends Component {
 		return cols;
 	}
 
-	getDataURL(namespace, typename, type, schema) {
-		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
-		return dataurl;
-	}
+	// getDataURL(namespace, typename, type, schema) {
+	// 	// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
+	// 	var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+	// 	return dataurl;
+	// }
 
 	getActions(namespace, typename, type, schema) {
 
@@ -207,6 +207,7 @@ class Instances extends Component {
 			typename, 
 			type, 
 			schema, 
+			dataurl 
 		} = this.props;
 
 		const { classes } = this.props;
@@ -258,12 +259,13 @@ class Instances extends Component {
 						type, 
 						schema
 					)}
-					dataurl={this.getDataURL(
-						namespace, 
-						typename, 
-						type, 
-						schema
-					)}
+					// dataurl={this.getDataURL(
+					// 	namespace, 
+					// 	typename, 
+					// 	type, 
+					// 	schema
+					// )}
+					dataurl={dataurl}
 					actions={this.getActions(
 						namespace, 
 						typename, 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -207,6 +207,12 @@ class RootInstance extends Component {
 
 	}
 
+	getDataURL(namespace, typename, type, schema) {
+		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
+		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+		return dataurl;
+	}
+
 	/*
 	 * Have to go back to commit cc6304f for this.
 	 * Sun Jul 26 20:54:32 2020 -0700
@@ -292,7 +298,12 @@ class RootInstance extends Component {
 			instance = this.state.instance;
 		}
 
-		var instance = undefined;
+		var dataurl = this.getDataURL(
+			namespace, 
+			typename, 
+			type, 
+			schema
+		);
 
 		return (
 			<>
@@ -336,6 +347,7 @@ class RootInstance extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
+						dataurl={dataurl} 
 						editable={false} 
 						showdeps={true} />
 				</Grid>

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -298,12 +298,12 @@ class RootInstance extends Component {
 			instance = this.state.instance;
 		}
 
-		var dataurl = this.getDataURL(
-			namespace, 
-			typename, 
-			type, 
-			schema
-		);
+		// var dataurl = this.getDataURL(
+		// 	namespace, 
+		// 	typename, 
+		// 	type, 
+		// 	schema
+		// );
 
 		return (
 			<>
@@ -347,7 +347,12 @@ class RootInstance extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
-						dataurl={dataurl} 
+						dataurl={_this.getDataURL(
+							namespace, 
+							typename, 
+							type["entity"], 
+							schema["entity"]
+						)} 
 						editable={false} 
 						showdeps={true} />
 				</Grid>

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -188,6 +188,12 @@ class RootInstances extends Component {
 
 	}
 
+	getDataURL(namespace, typename, type, schema) {
+		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
+		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+		return dataurl;
+	}
+
 	createInstance(type, data) {
 		const {api} = this.props;
 		this.props.createInstance(api, type, data);
@@ -291,6 +297,13 @@ class RootInstances extends Component {
 		var open = true;
 		var direction = "up";
 
+		var dataurl = this.getDataURL(
+			namespace, 
+			typename, 
+			type, 
+			schema
+		);
+
 		var actions = [
 			{
 				name: "Create new " + typename, 
@@ -338,6 +351,7 @@ class RootInstances extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
+						dataurl={dataurl} 
 						editable={true} 
 						showdeps={true} /> 
 				</Grid>

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -297,12 +297,12 @@ class RootInstances extends Component {
 		var open = true;
 		var direction = "up";
 
-		var dataurl = this.getDataURL(
-			namespace, 
-			typename, 
-			type, 
-			schema
-		);
+		// var dataurl = this.getDataURL(
+		// 	namespace, 
+		// 	typename, 
+		// 	type, 
+		// 	schema
+		// );
 
 		var actions = [
 			{
@@ -351,7 +351,12 @@ class RootInstances extends Component {
 						typename={typename} 
 						type={type["entity"]} 
 						schema={schema["entity"]} 
-						dataurl={dataurl} 
+						dataurl={_this.getDataURL(
+							namespace, 
+							typename, 
+							type["entity"], 
+							schema["entity"]
+						)} 
 						editable={true} 
 						showdeps={true} /> 
 				</Grid>


### PR DESCRIPTION
The getDataURL data url builder needs to be more flexible so that
different views can pass in different urls to the instances view.
This is so that boot root instances views, and instance fields views
can show accurate listings.
