### PR TITLE
Remove all host harcodings in data url.

### DIFF
--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -57,10 +57,8 @@ class Instance extends Component {
 
 	}
 
-	getDataURL(namespace, typename, type, schema, instance, instancefield) {
-		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		// var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename + "/" + instance["_id"] + "/" + instancefield;
+	getDataURL(api, namespace, typename, type, schema, instance, instancefield) {
+		var dataurl = "http://" + api.api.host + ":" + api.api.port + "/api/v2.0/" + namespace + "/" + typename + "/" + instance["_id"] + "/" + instancefield;
 		return dataurl;
 	}
 
@@ -204,19 +202,14 @@ class Instance extends Component {
 		showdeps
 	) {
 
-		var _this = this;
-
-		// const {
-		// 	api, 
-		// 	namespace, 
-		// 	typename, 
-		// 	type, 
-		// 	schema
-		// } = this.props;
+		const {
+			api, 
+		} = this.props;
 
 		return <InstancesView 
 			title={title} 
 			description={description} 
+			api={api} 
 			namespace={namespace} 
 			typename={typename} 
 			type={type} 
@@ -238,19 +231,14 @@ class Instance extends Component {
 		showdeps
 	) {
 
-		var _this = this;
-
-		// const {
-		// 	api, 
-		// 	namespace, 
-		// 	typename, 
-		// 	type, 
-		// 	schema
-		// } = this.props;
+		const {
+			api, 
+		} = this.props;
 
 		return <InstanceView 
 			title={title} 
 			description={description} 
+			api={api} 
 			namespace={namespace} 
 			typename={typename} 
 			type={type} 
@@ -265,6 +253,7 @@ class Instance extends Component {
 		var _this = this;
 
 		const {
+			api, 
 			namespace, 
 			title, 
             description, 
@@ -319,6 +308,7 @@ class Instance extends Component {
 							deptype, 
 							depschema, 
 							_this.getDataURL(
+								api, 
 								namespace, 
 								typename, // deptypename, 
 								type, // deptype, 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -207,16 +207,13 @@ class RootInstance extends Component {
 
 	}
 
-	getDataURL(namespace, typename, type, schema) {
-		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+	getDataURL(api, namespace, typename, type, schema) {
+		var dataurl = "http://" + api.api.host + ":" + api.api.port + "/api/v2.0/" + namespace + "/" + typename;
 		return dataurl;
 	}
 
-	getDataURL2(namespace, typename, type, schema, instance, instancefield) {
-		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		// var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename + "/" + instance["_id"] + "/" + instancefield;
+	getDataURL2(api, namespace, typename, type, schema, instance, instancefield) {
+		var dataurl = "http://" + api.api.host + ":" + api.api.port + "/api/v2.0/" + namespace + "/" + typename + "/" + instance["_id"] + "/" + instancefield;
 		return dataurl;
 	}
 
@@ -409,19 +406,14 @@ class RootInstance extends Component {
 		showdeps
 	) {
 
-		var _this = this;
-
-		// const {
-		// 	api, 
-		// 	namespace, 
-		// 	typename, 
-		// 	type, 
-		// 	schema
-		// } = this.props;
+		const {
+			api, 
+		} = this.props;
 
 		return <InstancesView 
 			title={title} 
 			description={description} 
+			api={api} 
 			namespace={namespace} 
 			typename={typename} 
 			type={type} 
@@ -443,19 +435,14 @@ class RootInstance extends Component {
 		showdeps
 	) {
 
-		var _this = this;
-
-		// const {
-		// 	api, 
-		// 	namespace, 
-		// 	typename, 
-		// 	type, 
-		// 	schema
-		// } = this.props;
+		const {
+			api, 
+		} = this.props;
 
 		return <InstanceView 
 			title={title} 
 			description={description} 
+			api={api} 
 			namespace={namespace} 
 			typename={typename} 
 			type={type} 
@@ -569,6 +556,7 @@ class RootInstance extends Component {
 							type["entity"], 
 							schema["entity"], 
 							_this.getDataURL(
+								api, 
 								namespace, 
 								typename, 
 								type["entity"], 
@@ -620,6 +608,7 @@ class RootInstance extends Component {
 								deptype, 
 								depschema, 
 								_this.getDataURL2(
+									api, 
 									namespace, 
 									typename, // deptypename, 
 									type, // deptype, 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -188,9 +188,8 @@ class RootInstances extends Component {
 
 	}
 
-	getDataURL(namespace, typename, type, schema) {
-		// return "http://192.168.1.112:5000/api/v2.0/archives/Files";
-		var dataurl = "http://192.168.1.112:5000/api/v2.0/" + namespace + "/" + typename;
+	getDataURL(api, namespace, typename, type, schema) {
+		var dataurl = "http://" + api.api.host + ":" + api.api.port + "/api/v2.0/" + namespace + "/" + typename;
 		return dataurl;
 	}
 
@@ -289,19 +288,14 @@ class RootInstances extends Component {
 		showdeps
 	) {
 
-		var _this = this;
-
-		// const {
-		// 	api, 
-		// 	namespace, 
-		// 	typename, 
-		// 	type, 
-		// 	schema
-		// } = this.props;
+		const {
+			api, 
+		} = this.props;
 
 		return <InstancesView 
 			title={title} 
 			description={description} 
+			api={api} 
 			namespace={namespace} 
 			typename={typename} 
 			type={type} 
@@ -392,6 +386,7 @@ class RootInstances extends Component {
 							type["entity"], 
 							schema["entity"], 
 							_this.getDataURL(
+								api, 
 								namespace, 
 								typename, 
 								type["entity"], 


### PR DESCRIPTION
Funny thing is that I thought I had fixed this earlier this summer, but I cannot find a commit for it anywhere. Anyhow, the data url methods should get the current API host details from the api state object and not hardcode any API host details.