### PR TITLE
Refacting column definitions for instances.

### DIFF
--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -198,6 +198,8 @@ class Instance extends Component {
 		type, 
 		schema, 
 		dataurl, 
+		columns, 
+		actions,  
 		editable, 
 		showdeps
 	) {
@@ -215,6 +217,8 @@ class Instance extends Component {
 			type={type} 
 			schema={schema} 
 			dataurl={dataurl} 
+			columns={columns} 
+			actions={actions} 
 			editable={editable} 
 			showdeps={showdeps} />
 	}
@@ -356,7 +360,7 @@ function mapStateToProps(state, ownProps) {
 		type, 
 		schema, 
 		instanceid, 
-		instance 
+		instance, 
 	} = ownProps;	
 
 	const {

--- a/src/components/Instances.js
+++ b/src/components/Instances.js
@@ -61,125 +61,58 @@ class Instances extends Component {
 
 	}
 
-	getListCols(namespace, typename, type, schema) {
+	// getListCols(namespace, typename, type, schema) {
+	// 	var cols = [];
+	// 	return cols;
+	// }
 
-		var cols = [];
-		cols.push({
-			title: "_name",
-			field: "_name",
-			// render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</a>
-			render: rowData => <Link to={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</Link>
-		});
-		cols.push({
-			title: "_id",
-			field: "_id",
-			editable: 'never',
-			// render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_id"]}</a>
-			render: rowData => <Link to={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_id"]}</Link>
-		});
-		// cols.push({
-		// 	title: "link",
-		// 	field: "link",
-		// 	render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</a>
-		// });
-		cols.push({
-			title: "_uuid",
-			field: "_uuid"
-		});
-		cols.push({
-			title: "_created",
-			field: "_created",
-			type: 'numeric'
-		});
-		cols.push({
-			title: "_modified",
-			field: "_modified",
-			type: 'numeric'
-		});
+	// getActions(namespace, typename, type, schema) {
+	// 
+	// 	const {
+	// 		editable
+	// 	} = this.props;
+    // 
+	// 	if( editable ) {
+	// 		return [
+	// 			// {
+	// 			// 	icon: 'save',
+	// 			// 	tooltip: 'Save', // + ' ' + typename,
+	// 			// 	onClick: (event, rowData) => window.alert("You saved " + rowData["_name"])
+	// 			// }, 
+	// 			{
+	// 				icon: 'delete',
+	// 				tooltip: 'Delete', // + ' ' + typename,
+	// 				onClick: (event, rowData) => window.confirm("Are you sure you want to delete" + " " + typename + " " + rowData["_name"] + "?")
+	// 			}, 
+	// 			// {
+	// 			// 	icon: 'add',
+	// 			// 	tooltip: 'Add User',
+	// 			// 	isFreeAction: true,
+	// 			// 	onClick: (event) => window.alert("Please fill out row")
+	// 			// }
+	// 			]
+	// 	} else {
+	// 		return []
+	// 	}
+	// 
+	// }
 
-		// if( type ) {
-		// 	if( type["properties"] ) {
-		if( schema ) {
-			if( schema["properties"] ) {
-				for( var propertyname in schema["properties"] ) {
-					var property = schema["properties"][propertyname];
-					if( property["$ref"] ) {
-						// 
-					} else if( (property["type"] == "array") && 
-							   (property["items"]) ) {
-						// 
-					} else {
-						if( !["_id", "_uuid", "_name", "_created", "_modified"].includes(propertyname) ) {
-
-							if( property["type"] == "integer" ) {
-								cols.push({
-									title: propertyname,
-									field: propertyname,
-									type: 'numeric'
-								});
-							} else {
-								cols.push({
-									title: propertyname,
-									field: propertyname
-								});
-							}
-
-						}
-					}
-				}
-			}
-		}
-
-		return cols;
-	}
-
-	getActions(namespace, typename, type, schema) {
-
-		const {
-			editable
-		} = this.props;
-
-		if( editable ) {
-			return [
-				// {
-				// 	icon: 'save',
-				// 	tooltip: 'Save', // + ' ' + typename,
-				// 	onClick: (event, rowData) => window.alert("You saved " + rowData["_name"])
-				// }, 
-				{
-					icon: 'delete',
-					tooltip: 'Delete', // + ' ' + typename,
-					onClick: (event, rowData) => window.confirm("Are you sure you want to delete" + " " + typename + " " + rowData["_name"] + "?")
-				}, 
-				// {
-				// 	icon: 'add',
-				// 	tooltip: 'Add User',
-				// 	isFreeAction: true,
-				// 	onClick: (event) => window.alert("Please fill out row")
-				// }
-				]
-		} else {
-			return []
-		}
-
-	}
-
-	getEditable(namespace, typename, type, schema) {
-
-		const {
-			editable
-		} = this.props;
-
-		if( editable ) {
-			return {
-				onRowAdd: newData => window.alert(""),
-				onRowUpdate: (newData, oldData) => window.alert(""),
-			}
-		} else {
-			return {}
-		}
-
-	}
+	// getEditable(namespace, typename, type, schema) {
+	// 
+	// 	const {
+	// 		editable
+	// 	} = this.props;
+	// 
+	// 	if( editable ) {
+	// 		return {
+	// 			onRowAdd: newData => window.alert(""),
+	// 			onRowUpdate: (newData, oldData) => window.alert(""),
+	// 		}
+	// 	} else {
+	// 		return {}
+	// 	}
+	// 
+	// }
 
 	makeInstanceLink(namespace, type, id) {
 		return "/namespaces/" + namespace + "/" + type + "/" + id;
@@ -201,45 +134,13 @@ class Instances extends Component {
 			typename, 
 			type, 
 			schema, 
-			dataurl 
+			dataurl, 
+			columns, 
+			actions, 
+			editable
 		} = this.props;
 
 		const { classes } = this.props;
-
-		var cols = [];
-		cols.push({
-			title: "_id",
-			field: "_id"
-		});
-		cols.push({
-			title: "_uuid",
-			field: "_uuid"
-		});
-		cols.push({
-			title: "_name",
-			field: "_name"
-		});
-		// cols.push({
-		// 	title: "_created",
-		// 	field: "_created"
-		// });
-		// cols.push({
-		// 	title: "_modified",
-		// 	field: "_modified"
-		// });
-
-		if( type ) {
-			if( type["properties"] ) {
-				for( var property in type["properties"] ) {
-					if( !["_id", "_uuid", "_name", "_created", "_modified"].includes(property) ) {
-						cols.push({
-							title: property,
-							field: property
-						});
-					}
-				}
-			}
-		}
 
 		return (
 			<>
@@ -247,25 +148,28 @@ class Instances extends Component {
 					title={title} 
 					description={description} 
 					tableRef={this.tableRef}
-					cols={this.getListCols(
-						namespace, 
-						typename, 
-						type, 
-						schema
-					)}
 					dataurl={dataurl}
-					actions={this.getActions(
-						namespace, 
-						typename, 
-						type, 
-						schema
-					)}
-					editable={this.getEditable(
-						namespace, 
-						typename, 
-						type, 
-						schema
-					)}
+					// cols={this.getListCols(
+					// 	namespace, 
+					// 	typename, 
+					// 	type, 
+					// 	schema
+					// )}
+					cols={columns}
+					// actions={this.getActions(
+					// 	namespace, 
+					// 	typename, 
+					// 	type, 
+					// 	schema
+					// )}
+					actions={actions}
+					// editable={this.getEditable(
+					// 	namespace, 
+					// 	typename, 
+					// 	type, 
+					// 	schema
+					// )}
+					editable={editable}
 					detailLink={(rowData) => this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} />
 			</>
 		);
@@ -286,6 +190,9 @@ function mapStateToProps(state, ownProps) {
 		typename, 
 		type, 
 		schema, 
+		dataurl, 
+		columns, 
+		actions, 
 		editable
 	} = ownProps;	
 
@@ -298,6 +205,9 @@ function mapStateToProps(state, ownProps) {
 		typename: typename, 
 		type: type, 
 		schema: schema, 
+		dataurl: dataurl, 
+		columns: columns, 
+		actions: actions, 
 		editable: editable
 	}
 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -402,6 +402,8 @@ class RootInstance extends Component {
 		type, 
 		schema, 
 		dataurl, 
+		columns, 
+		actions, 
 		editable, 
 		showdeps
 	) {
@@ -419,6 +421,8 @@ class RootInstance extends Component {
 			type={type} 
 			schema={schema} 
 			dataurl={dataurl} 
+			columns={columns} 
+			actions={actions} 
 			editable={editable} 
 			showdeps={showdeps} />
 	}
@@ -467,6 +471,7 @@ class RootInstance extends Component {
 		} = this.props;
 
 		const { classes } = this.props;
+
 
 		var backdropOpen = false;
 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -214,50 +214,58 @@ class RootInstances extends Component {
 		cols.push({
 			title: "_name",
 			field: "_name",
-			// render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</a>
 			render: rowData => <Link to={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</Link>
 		});
-		cols.push({
-			title: "_id",
-			field: "_id",
-			editable: 'never',
-			// render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_id"]}</a>
-			render: rowData => <Link to={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_id"]}</Link>
-		});
-		// cols.push({
-		// 	title: "link",
-		// 	field: "link",
-		// 	render: rowData => <a href={this.makeInstanceLink(namespace, rowData["_label"], rowData["_id"])} style={{width: 50, borderRadius: '50%'}}>{rowData["_name"]}</a>
-		// });
-		cols.push({
-			title: "_uuid",
-			field: "_uuid"
-		});
-		cols.push({
-			title: "_created",
-			field: "_created",
-			type: 'numeric'
-		});
-		cols.push({
-			title: "_modified",
-			field: "_modified",
-			type: 'numeric'
-		});
-
-		if( type ) {
-			if( type["properties"] ) {
-				for( var property in type["properties"] ) {
-					if( !["_id", "_uuid", "_name", "_created", "_modified"].includes(property) ) {
-						cols.push({
-							title: property,
-							field: property
-						});
-					}
-				}
-			}
-		}
 
 		return cols;
+	}
+
+	getActions(namespace, typename, type, schema) {
+
+		const {
+			editable
+		} = this.props;
+
+		if( editable ) {
+			return [
+				// {
+				// 	icon: 'save',
+				// 	tooltip: 'Save', // + ' ' + typename,
+				// 	onClick: (event, rowData) => window.alert("You saved " + rowData["name"])
+				// }, 
+				{
+					icon: 'delete',
+					tooltip: 'Delete', // + ' ' + typename,
+					onClick: (event, rowData) => window.confirm("Are you sure you want to delete" + " " + typename + " " + rowData["name"] + "?")
+				}, 
+				// {
+				// 	icon: 'add',
+				// 	tooltip: 'Add User',
+				// 	isFreeAction: true,
+				// 	onClick: (event) => window.alert("Please fill out row")
+				// }
+				]
+		} else {
+			return []
+		}
+
+	}
+
+	getEditable(namespace, typename, type, schema) {
+
+		const {
+			editable
+		} = this.props;
+
+		if( editable ) {
+			return {
+				onRowAdd: newData => window.alert(""),
+				onRowUpdate: (newData, oldData) => window.alert(""),
+			}
+		} else {
+			return {}
+		}
+
 	}
 
 	makeCreateInstanceLink(namespace, type) {
@@ -284,6 +292,8 @@ class RootInstances extends Component {
 		type, 
 		schema, 
 		dataurl, 
+		columns, 
+		actions, 
 		editable, 
 		showdeps
 	) {
@@ -301,6 +311,8 @@ class RootInstances extends Component {
 			type={type} 
 			schema={schema} 
 			dataurl={dataurl} 
+			columns={columns} 
+			actions={actions} 
 			editable={editable} 
 			showdeps={showdeps} />
 	}
@@ -387,6 +399,24 @@ class RootInstances extends Component {
 							schema["entity"], 
 							_this.getDataURL(
 								api, 
+								namespace, 
+								typename, 
+								type["entity"], 
+								schema["entity"]
+							), 
+							_this.getListCols(
+								namespace, 
+								typename, 
+								type["entity"], 
+								schema["entity"]
+							), 
+							_this.getActions(
+								namespace, 
+								typename, 
+								type["entity"], 
+								schema["entity"]
+							), 
+							_this.getEditable(
 								namespace, 
 								typename, 
 								type["entity"], 


### PR DESCRIPTION
The getListCols, getActions and getEditable methods needs to be more flexible so that different views can pass in different sets of colums to be displayed in instance views.