### PR TITLE
Switching graph views to use graph API.

### DIFF
--- a/src/components/Namespaces.js
+++ b/src/components/Namespaces.js
@@ -103,7 +103,7 @@ class Namespaces extends Component {
 
 	};
 
-	getTreeData(vertexes, edges) {
+	getTreeData(graph) {
 
 		var treestruc = {
 			


### PR DESCRIPTION
Switching graph views to use graph API. The graph views uses the non paging 1.0 REST API graph vertex and edge endpoints which does not work with large graphs. This has to be switched to usingequivalent 2.0 REST API pageable graph endpoints.