### PR TITLE
Dynamically created root and root instance views classes.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -127,7 +127,8 @@ function TreeViewItems(props) {
 	)
 }
 
-class Root extends Component {
+// class Root extends Component {
+const Root = class extends Component {
 
 	constructor(props) {
 		super(props);
@@ -833,4 +834,11 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root));
+function makeRootView() {
+	return connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root));
+}
+
+// export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root));
+export {
+	makeRootView
+};

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -137,7 +137,8 @@ function TreeViewItems(props) {
 	)
 }
 
-class RootInstances extends Component {
+// class RootInstances extends Component {
+const RootInstances = class extends Component {
 
 	constructor(props) {
 		super(props);
@@ -920,4 +921,11 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances));
+function makeRootInstancesView() {
+	return connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances));
+}
+
+// export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances));
+export {
+	makeRootInstancesView
+};

--- a/src/index.js
+++ b/src/index.js
@@ -47,9 +47,13 @@ import App from './App.js';
 // import InstancesView from './components/Instances'
 // import InstanceView from './components/Instance'
 
-import RootInstancesView from './components/RootInstances'
+// import RootInstancesView from './components/RootInstances'
+import { makeRootInstancesView } from './components/RootInstances'
+
 import RootInstanceView from './components/RootInstance'
-import RootView from './components/Root'
+
+// import RootView from './components/Root'
+import { makeRootView } from './components/Root'
 
 // import SubInstancesView from './components/SubInstances'
 // import SubInstanceView from './components/SubInstance'
@@ -202,8 +206,9 @@ ReactDOM.render(
 				exact 
 				path="/namespaces/:namespace" 
 				render={
-					(props) => 
-						<>
+					(props) => {
+						const RootView = makeRootView();
+						return(<>
 						<App 
 							namespace={props.match.params.namespace} 
 							typename={props.match.params.typename} 
@@ -213,8 +218,9 @@ ReactDOM.render(
 							typename={props.match.params.typename} 
 						/>
 						</App>
-						</>
-				} />
+						</>);
+					}
+				}/>
 			{/* <Route 
 				exact 
 				path="/dashboard" 
@@ -232,8 +238,9 @@ ReactDOM.render(
 				exact 
 				path="/namespaces/:namespace/:typename" 
 				render={
-					(props) => 
-						<>
+					(props) => {
+						const RootInstancesView = makeRootInstancesView();
+						return(<>
 						<App 
 							namespace={props.match.params.namespace} 
 							typename={props.match.params.typename} 
@@ -243,8 +250,9 @@ ReactDOM.render(
 							typename={props.match.params.typename} 
 						/>
 						</App>
-						</>
-				} />
+						</>);
+					}
+				}
 			<Route 
 				exact 
 				path="/namespaces/:namespace/create/:typename" 


### PR DESCRIPTION
Switching to using dynamically created root and root instance views classes when building app routes. When using the same class in more than one route I see refresh events that prevent the right data to be displayed even thought the data is different between the views. Swithing to using separate classes for each route, with each separate class being created for one particular graph type, resolves this.