### PR TITLE
Switching graph views to use graph API.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -284,7 +284,7 @@ function getType(props, types) {
 		for( var typeid in types["data"] ) {
 			if( typeid ) {
 				var type = types["data"][typeid];
-				if( (type) && (type["name"] == typename) ) {
+				if( (type) && (type["_name"] == typename) ) {
 					return type;
 				}
 			}
@@ -515,8 +515,8 @@ const AppDrawer = withStyles(styles)(function({ classes, variant, open, onClose,
 				var type = types["data"][typeid];
 				if( type ) {
 					miditems.push({
-						"text": type["name"], 
-						"path": "/namespaces/" + currentns + "/" + type["name"], 
+						"text": type["_name"], 
+						"path": "/namespaces/" + currentns + "/" + type["_name"], 
 						"icon": <ExtensionIcon/>, 
 						"selected": false
 					});

--- a/src/components/Instance.js
+++ b/src/components/Instance.js
@@ -309,7 +309,7 @@ class Instance extends Component {
 						var depschema = schema["definitions"][deptypename];
 						depschema["definitions"] = schema["definitions"];
 						return _this.makeInstancesView(
-							item && item["name"], 
+							item && item["_name"], 
 							item && item.type + " " + "(" + item.cardinality + ")",  
 							namespace, 
 							deptypename, 
@@ -322,7 +322,7 @@ class Instance extends Component {
 								type, // deptype, 
 								schema, // depschema, 
 								instance, // item && item.value, 
-								item && item["name"]
+								item && item["_name"]
 							), 
 							false
 						);
@@ -332,7 +332,7 @@ class Instance extends Component {
 						var depschema = schema["definitions"][deptypename];
 						depschema["definitions"] = schema["definitions"];
 						return _this.makeInstanceView(
-							item && item["name"], 
+							item && item["_name"], 
 							item && item.type + " " + "(" + item.cardinality + ")", 
 							namespace, 
 							deptypename, 

--- a/src/components/RelInstance.js
+++ b/src/components/RelInstance.js
@@ -233,7 +233,7 @@ class RelInstance extends Component {
 					{typename}
 				</Link>
 				<Link color="inherit" to={"/namespaces/" + namespace + "/" + typename + "/" + instanceid}>
-					{ instance && instance["entity"] && instance["entity"]["name"] }
+					{ instance && instance["entity"] && instance["entity"]["_name"] }
 				</Link>
 				<Typography color="textPrimary">{ relname }</Typography>
 				<ForwardNavButton></ForwardNavButton>

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -272,12 +272,12 @@ class RootInstance extends Component {
 				// {
 				// 	icon: 'save',
 				// 	tooltip: 'Save', // + ' ' + typename,
-				// 	onClick: (event, rowData) => window.alert("You saved " + rowData["name"])
+				// 	onClick: (event, rowData) => window.alert("You saved " + rowData["_name"])
 				// }, 
 				{
 					icon: 'delete',
 					tooltip: 'Delete', // + ' ' + typename,
-					onClick: (event, rowData) => window.confirm("Are you sure you want to delete" + " " + typename + " " + rowData["name"] + "?")
+					onClick: (event, rowData) => window.confirm("Are you sure you want to delete" + " " + typename + " " + rowData["_name"] + "?")
 				}, 
 				// {
 				// 	icon: 'add',
@@ -695,7 +695,7 @@ class RootInstance extends Component {
 					spacing={0} 
 				>
 						{_this.makeInstanceView(
-							instance && ( instance["name"] + " (" + instance["_id"] + ")"), 
+							instance && ( instance["_name"] + " (" + instance["_id"] + ")"), 
 							typename, 
 							namespace, 
 							typename, 

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ store.dispatch(selectApi(defaultEndpoint));
 // 		for( var typeid in types ) {
 // 			if( typeid ) {
 // 				var type = types[typeid];
-// 				if( (type) && (type["name"] == typename) ) {
+// 				if( (type) && (type["_name"] == typename) ) {
 // 					return type;
 // 				}
 // 			}


### PR DESCRIPTION
Switching graph views to use graph API. The graph views uses the non paging 1.0 REST API graph vertex and edge endpoints which does not work with large graphs. This has to be switched to usingequivalent 2.0 REST API pageable graph endpoints.