### PR TITLE
Replacing vuerd with erd-editor.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gfsapp",
       "version": "0.1.0",
       "dependencies": {
+        "@dineug/erd-editor": "^3.2.3",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.3.0",
         "@jsonforms/core": "^2.5.2",
@@ -57,7 +58,6 @@
         "socket.io-client": "^4.7.2",
         "storm-react-diagrams": "^5.2.1",
         "typescript": "^4.3.5",
-        "erd-editor": "^3.2.2",
         "worker-loader": "^3.0.8"
       }
     },
@@ -2369,6 +2369,11 @@
       "peerDependencies": {
         "moment": "^2.24.0"
       }
+    },
+    "node_modules/@dineug/erd-editor": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@dineug/erd-editor/-/erd-editor-3.2.3.tgz",
+      "integrity": "sha512-BYfsEc29mG2EMCE/QZJ+1bgriEn1myjpXXu/fHp3FcgTYr5fgqa2X/am2qIhxtOB0pWm3niLPQzjdblzImvSRA=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -20177,12 +20182,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
-    "node_modules/vuerd": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/vuerd/-/vuerd-1.3.7.tgz",
-      "integrity": "sha512-JO2haaiLqt546A2gFlkjON3/0NMwHiaaKnO2teUb1tOY3xSasXsQzWMzMUWibjNu0JFqsY4mdfsRhJZ9KVL1BA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -22717,6 +22716,11 @@
       "requires": {
         "@date-io/core": "^1.3.11"
       }
+    },
+    "@dineug/erd-editor": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@dineug/erd-editor/-/erd-editor-3.2.3.tgz",
+      "integrity": "sha512-BYfsEc29mG2EMCE/QZJ+1bgriEn1myjpXXu/fHp3FcgTYr5fgqa2X/am2qIhxtOB0pWm3niLPQzjdblzImvSRA=="
     },
     "@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -35683,11 +35687,6 @@
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
-    },
-    "vuerd": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/vuerd/-/vuerd-1.3.7.tgz",
-      "integrity": "sha512-JO2haaiLqt546A2gFlkjON3/0NMwHiaaKnO2teUb1tOY3xSasXsQzWMzMUWibjNu0JFqsY4mdfsRhJZ9KVL1BA=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "proxy": "http://localhost:5000",
   "dependencies": {
+    "@dineug/erd-editor": "^3.2.3",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.3.0",
     "@jsonforms/core": "^2.5.2",
@@ -53,7 +54,6 @@
     "socket.io-client": "^4.7.2",
     "storm-react-diagrams": "^5.2.1",
     "typescript": "^4.3.5",
-    "erd-editor": "^3.2.2",
     "worker-loader": "^3.0.8"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,11 @@
   dependencies:
     "@date-io/core" "^1.3.11"
 
+"@dineug/erd-editor@^3.2.3":
+  "integrity" "sha512-BYfsEc29mG2EMCE/QZJ+1bgriEn1myjpXXu/fHp3FcgTYr5fgqa2X/am2qIhxtOB0pWm3niLPQzjdblzImvSRA=="
+  "resolved" "https://registry.npmjs.org/@dineug/erd-editor/-/erd-editor-3.2.3.tgz"
+  "version" "3.2.3"
+
 "@emotion/babel-plugin@^11.11.0":
   "integrity" "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ=="
   "resolved" "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz"
@@ -11461,11 +11466,6 @@
   "integrity" "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
   "resolved" "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz"
   "version" "3.17.3"
-
-"vuerd@^1.3.7":
-  "integrity" "sha512-JO2haaiLqt546A2gFlkjON3/0NMwHiaaKnO2teUb1tOY3xSasXsQzWMzMUWibjNu0JFqsY4mdfsRhJZ9KVL1BA=="
-  "resolved" "https://registry.npmjs.org/vuerd/-/vuerd-1.3.7.tgz"
-  "version" "1.3.7"
 
 "w3c-hr-time@^1.0.2":
   "integrity" "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ=="


### PR DESCRIPTION
Replacing vuerd with erd-editor. The vuerd editor package is deprecated and replaced with the @dineug/erd-editor.