### PR TITLE
Working on replacing react router 5 with 6.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -12,11 +12,14 @@ import { withStyles } from '@material-ui/styles';
 // import { useHistory } from "react-router-dom";
 
 import {
+	Routes, 
 	BrowserRouter as Router,
 	Switch,
 	Route,
 	Link,
-	useRouteMatch
+	useRouteMatch, 
+	useParams, 
+	useNavigate
 } from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
@@ -821,13 +824,14 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
 
 	const {
-		namespace
-	} = ownProps;
-
-	const {
 		api, 
 		// namespace
 	} = state;
+
+	var namespace = undefined;
+	if( ownProps && ownProps.params ) {
+		namespace = ownProps.params.namespace;
+	}
 
 	return {
 		api, 
@@ -836,4 +840,16 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root));
+/*
+ * https://github.com/remix-run/react-router/issues/8146
+ */
+
+function withNavigation(Component) {
+	return props => <Component {...props} navigate={useNavigate()} />;
+}
+
+function withParams(Component) {
+	return props => <Component {...props} params={useParams()} />;
+}
+
+export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root)));

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -14,7 +14,9 @@ import {
 	Switch,
 	Route,
 	Link,
-	useRouteMatch
+	useRouteMatch, 
+	useParams, 
+	useNavigate
 } from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
@@ -781,14 +783,24 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
 
 	const {
-		namespace, 
-		typename, 
-		instanceid
-	} = ownProps;
-
-	const {
-		api
+		api, 
+		// namespace
 	} = state;
+
+	var namespace = undefined;
+	if( ownProps && ownProps.params ) {
+		namespace = ownProps.params.namespace;
+	}
+
+	var typename = undefined;
+	if( ownProps && ownProps.params ) {
+		typename = ownProps.params.typename;
+	}
+
+	var instanceid = undefined;
+	if( ownProps && ownProps.params ) {
+		instanceid = ownProps.params.instanceid;
+	}
 
 	const type = getEntityFromState(state, api, namespace, "type", typename);
 
@@ -805,4 +817,16 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstance));
+/*
+ * https://github.com/remix-run/react-router/issues/8146
+ */
+
+function withNavigation(Component) {
+	return props => <Component {...props} navigate={useNavigate()} />;
+}
+
+function withParams(Component) {
+	return props => <Component {...props} params={useParams()} />;
+}
+
+export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstance)));

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -12,12 +12,15 @@ import { withStyles } from '@material-ui/styles';
 // import { useHistory } from "react-router-dom";
 
 import {
-	BrowserRouter as Router,
-	Switch,
-	Route,
-	Link,
-	useRouteMatch
-} from "react-router-dom";
+	Routes, 
+		BrowserRouter as Router,
+		Switch,
+		Route,
+		Link,
+		useRouteMatch, 
+		useParams, 
+		useNavigate
+	} from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
@@ -899,15 +902,19 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
 
 	const {
-		namespace, 
-		typename, 
-		// instanceid
-	} = ownProps;
-
-	const {
 		api, 
 		// namespace
 	} = state;
+
+	var namespace = undefined;
+	if( ownProps && ownProps.params ) {
+		namespace = ownProps.params.namespace;
+	}
+
+	var typename = undefined;
+	if( ownProps && ownProps.params ) {
+		typename = ownProps.params.typename;
+	}
 
 	const type = getEntityFromState(state, api, namespace, "type", typename);
 
@@ -923,4 +930,16 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances));
+/*
+ * https://github.com/remix-run/react-router/issues/8146
+ */
+
+function withNavigation(Component) {
+	return props => <Component {...props} navigate={useNavigate()} />;
+}
+
+function withParams(Component) {
+	return props => <Component {...props} params={useParams()} />;
+}
+
+export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances)));


### PR DESCRIPTION
Working on replacing react router 5 with 6 after upgrading the react router plugin to overcome navigational link issues. There has been a lot of changes in the react router plugin that requires structural code changes when setting up navigational routes.