### PR TITLE
Working on replacing react router 5 with 6.

### DIFF
--- a/src/components/Namespaces.js
+++ b/src/components/Namespaces.js
@@ -15,7 +15,14 @@ import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 
 import {
-	Link
+	Routes, 
+	BrowserRouter as Router,
+	Switch,
+	Route,
+	Link,
+	useRouteMatch, 
+	useParams, 
+	useNavigate
 } from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
@@ -208,12 +215,14 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
 
 	const {
-		namespace
-	} = ownProps;
-
-	const {
-		api
+		api, 
+		// namespace
 	} = state;
+
+	var namespace = undefined;
+	if( ownProps && ownProps.params ) {
+		namespace = ownProps.params.namespace;
+	}
 
 	const {
 		loading: nsloading, 
@@ -235,4 +244,16 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Namespaces));
+/*
+ * https://github.com/remix-run/react-router/issues/8146
+ */
+
+function withNavigation(Component) {
+	return props => <Component {...props} navigate={useNavigate()} />;
+}
+
+function withParams(Component) {
+	return props => <Component {...props} params={useParams()} />;
+}
+
+export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Namespaces)));

--- a/src/components/RelInstance.js
+++ b/src/components/RelInstance.js
@@ -10,11 +10,14 @@ import { withStyles } from '@material-ui/styles';
 // import { useHistory } from "react-router-dom";
 
 import {
+	Routes, 
 	BrowserRouter as Router,
 	Switch,
 	Route,
 	Link,
-	useRouteMatch
+	useRouteMatch, 
+	useParams, 
+	useNavigate
 } from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
@@ -297,15 +300,29 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
 
 	const {
-		namespace, 
-		typename, 
-		instanceid, 
-		relname
-	} = ownProps;
-
-	const {
-		api
+		api, 
+		// namespace
 	} = state;
+
+	var namespace = undefined;
+	if( ownProps && ownProps.params ) {
+		namespace = ownProps.params.namespace;
+	}
+
+	var typename = undefined;
+	if( ownProps && ownProps.params ) {
+		typename = ownProps.params.typename;
+	}
+
+	var instanceid = undefined;
+	if( ownProps && ownProps.params ) {
+		instanceid = ownProps.params.instanceid;
+	}
+
+	var relname = undefined;
+	if( ownProps && ownProps.params ) {
+		relname = ownProps.params.relname;
+	}
 
 	const instance = getEntityFromState(state, api, namespace, typename, instanceid);
 
@@ -331,4 +348,16 @@ function mapStateToProps(state, ownProps) {
 
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RelInstance));
+/*
+ * https://github.com/remix-run/react-router/issues/8146
+ */
+
+function withNavigation(Component) {
+	return props => <Component {...props} navigate={useNavigate()} />;
+}
+
+function withParams(Component) {
+	return props => <Component {...props} params={useParams()} />;
+}
+
+export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RelInstance)));


### PR DESCRIPTION
Working on replacing react router 5 with 6 after upgrading the react router plugin to overcome navigational link issues. There has been a lot of changes in the react router plugin that requires structural code changes when setting up navigational routes.