### PR TITLE
Moving selected item state out of graph view.

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -324,24 +324,25 @@ class Graph extends Component {
 
 	constructor(props) {
 		super(props);
-		// this.state = {
-		// 	exploded: false, 
-		// 	selected: undefined
-		// }
-		var id = props.selected;
-		if(id) {
-			// this.setState({
-			this.state = {
-				exploded: false, 
-				selected: id,
-			};
-		} else {
-			// this.setState({
-			this.state = {
-				exploded: false, 
-				selected: undefined
-			};
+		this.state = {
+			// exploded: false, 
+			// selected: undefined
+			dummy: false
 		}
+		// var id = props.selected;
+		// if(id) {
+		// 	// this.setState({
+		// 	this.state = {
+		// 		exploded: false, 
+		// 		selected: id,
+		// 	};
+		// } else {
+		// 	// this.setState({
+		// 	this.state = {
+		// 		exploded: false, 
+		// 		selected: undefined
+		// 	};
+		// }
 
 		var _this = this;
 
@@ -353,35 +354,36 @@ class Graph extends Component {
 	}
 
 	state = {
-		exploded: false, 
-		selected: undefined
+		// exploded: false, 
+		// selected: undefined
+		dummy: false
 	};
 
 	componentWillUpdate(nextProps, nextState) {
 
 		const {
-			api, 
-			namespace, 
-			graph, 
-			width, 
-			height, 
-			selected
+			// api, 
+			// namespace, 
+			// graph, 
+			// width, 
+			// height, 
+			// selected
 		} = this.props;
 
-		if( this.props.selected != nextProps.selected ) {
-			var id = nextProps.selected; // selected;
-			if(id) {
-				this.setState({
-					exploded: false, // this.state.exploded, 
-					selected: id
-				});
-			} else {
-				this.setState({
-					exploded: false, // this.state.exploded, 
-					selected: undefined
-				});
-			}
-		} 
+		// if( this.props.selected != nextProps.selected ) {
+		// 	var id = nextProps.selected; // selected;
+		// 	if(id) {
+		// 		this.setState({
+		// 			exploded: false, // this.state.exploded, 
+		// 			selected: id
+		// 		});
+		// 	} else {
+		// 		this.setState({
+		// 			exploded: false, // this.state.exploded, 
+		// 			selected: undefined
+		// 		});
+		// 	}
+		// } 
 		// else if( this.props.selected == nextProps.selected ) {
 		// 	var id = nextProps.selected; // selected;
 		// 	this.setState({
@@ -395,12 +397,12 @@ class Graph extends Component {
 	componentDidUpdate(prevProps, prevState) {
 
 		const {
-			api, 
-			namespace, 
-			graph, 
-			width, 
-			height, 
-			selected
+			// api, 
+			// namespace, 
+			// graph, 
+			// width, 
+			// height, 
+			// selected
 		} = this.props;
 
 		// if(
@@ -426,12 +428,12 @@ class Graph extends Component {
 	componentDidMount() {
 
 		const {
-			api, 
-			namespace, 
-			graph, 
-			width, 
-			height, 
-			selected
+			// api, 
+			// namespace, 
+			// graph, 
+			// width, 
+			// height, 
+			// selected
 		} = this.props;
 
 		// if(
@@ -633,21 +635,35 @@ class Graph extends Component {
 	};
 
 	selectItem(id) {
-		if( id && id == this.props.selected ) {
-			this.setState({
-				exploded: !this.state.exploded
-			});
-		} else {
-			this.setState({
-				exploded: false
-			});
-			if( this.props.selectItem ) {
-				this.props.selectItem(id);
+
+		var vidpfx = "v"; // "#";
+		var eidpfx = "e"; // "";
+
+		// if( id && id == this.props.selected ) {
+		// 	this.setState({
+		// 		exploded: false // !this.state.exploded
+		// 	});
+		// } else {
+		// 	this.setState({
+		// 		exploded: false
+		// 	});
+		if( this.props.selectItem ) {
+			if( id ) {
+				this.props.selectItem(id.replace(vidpfx, ''));
+			} else {
+				this.props.selectItem(undefined);
 			}
 		}
+		this.setState({
+			dummy: false
+		});
+		// }
 	}
 
 	render() {
+
+		var vidpfx = "v"; // "#";
+		var eidpfx = "e"; // "";
 
 		const {
 			api, 
@@ -702,23 +718,44 @@ class Graph extends Component {
 
 		// var highlighted = this.state.highlighted;
 		// var exploded = this.state.exploded;
-		var selected = this.state.selected;
+		// var selected = this.state.selected;
 		// var refreshed = this.state.refreshed;
 		// var pulsed = this.state.refreshed;
 		// var runLayout = this.state.runLayout;
 		// var zoomFit = this.state.zoomFit;
 
-		var highlighted = selected; // this.state.highlighted;
-		var exploded = undefined; // this.state.exploded;
-		if( this.state.exploded ) {
-			highlighted = undefined; // this.state.highlighted;
-			exploded = selected; // this.state.exploded;
+		// var highlighted = selected; // this.state.highlighted;
+		// var exploded = undefined; // this.state.exploded;
+		// if( this.state.exploded ) {
+		// 	highlighted = undefined; // this.state.highlighted;
+		// 	exploded = selected; // this.state.exploded;
+		// }
+
+		var selected = undefined;
+		var highlighted = undefined;
+		var exploded = undefined;
+
+		if( this.props.selected ) {
+			selected = vidpfx + this.props.selected;
 		}
+
+		if( this.props.highlighted ) {
+			highlighted = vidpfx + this.props.highlighted;
+		}
+
+		if( this.props.exploded ) {
+			exploded = vidpfx + this.props.exploded;
+		}
+
 		// var selected = this.state.selected;
 		// var refreshed = this.state.refreshed;
-		var pulsed = true; // this.state.refreshed;
-		var runLayout = true; // this.state.runLayout;
-		var zoomFit = true; // this.state.zoomFit;
+		// var pulsed = true; // this.state.refreshed;
+		// var runLayout = true; // this.state.runLayout;
+		// var zoomFit = true; // this.state.zoomFit;
+
+		var pulsed = this.props.pulsed;
+		var runLayout = this.props.runLayout;
+		var zoomFit = this.props.zoomFit;
 
 		return (
 			<>

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -51,6 +51,10 @@ import APIClient from '../clients/APIClient';
 import Graph from './Graph';
 import ThreeDeeGraph from './ThreeDeeGraph';
 
+import history from '../history'
+// import { useNavigate } from "react-router-dom";
+// const navigate = useNavigate();
+
 const styles = theme => ({
 
 	mainContainer: {
@@ -144,13 +148,12 @@ const Root = class extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
+			// intendedcenter: undefined, 
+			// actualcenter: undefined, 
 			insloading: false, 
 			insloaded: false, 
 			insfailed: false, 
-			instanceid: undefined, 
-			instance: undefined, 
-			graph: undefined, 
-			selected: undefined
+			graph: undefined
 		}
 
 		var _this = this;
@@ -163,13 +166,12 @@ const Root = class extends Component {
 	}
 
 	state = {
+		// intendedcenter: undefined, 
+		// actualcenter: undefined, 
 		insloading: false, 
 		insloaded: false, 
 		insfailed: false, 
-		instanceid: undefined, 
-		instance: undefined, 
-		graph: undefined, 
-		selected: undefined
+		graph: undefined
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -179,24 +181,67 @@ const Root = class extends Component {
 
 		const {
 			api, 
-			namespace
+			namespace, 
+			typename, 
+			type, 
+			schema
 		} = this.props;
+
+		// if( (!this.props.type["loading"]) && 
+		// 	(!this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+		// 	// if( typename ) {
+		// 	if( api && namespace && typename ) {
+		// 		this.props.loadType(api, namespace, typename);
+		// 	}
+		// 	// }
+		// }
+
+		// if( (!this.props.schema["loading"]) && 
+		// 	(!this.props.schema["loaded"]) && 
+		// 	(!this.props.schema["failed"]) ) {
+		// 	// if( typename ) {
+		// 	if( api && namespace && typename ) {
+		// 		this.props.loadSchema(api, namespace, typename);
+		// 	}
+		// 	// }
+		// }
+
+		// var center = undefined;
+		// if( !center ) {
+		// 	if( type && type["entity"] && type["entity"]["_id"] ) {
+		// 		center = type["entity"]["_id"];
+		// 	}
+		// }
+
+		// if( center != this.state.intendedcenter ) {
+		// 	this.setState({
+		// 		intendedcenter: center, 
+		// 		insloading: false, 
+		// 		insloaded: false, 
+		// 		insfailed: false
+		// 	});
+		// }
 
 		/*
 		 * Have to go back to commit cc6304f for this.
 		 * Sun Jul 26 20:54:32 2020 -0700
 		 * Sun Mar 29 16:20:36 2020 -0500
 		 */
-		if( (!this.state.insloading) && 
-			(!this.state.insloaded) && 
-			(!this.state.insfailed) ) {
-			this.loadInstance(
-				api, 
-				namespace, 
-				"graph", 
-				this.state.instanceid
-			)
-		}
+		// if( (!this.props.type["loading"]) && 
+		// 	(this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+			if( (!this.state.insloading) && 
+				(!this.state.insloaded) && 
+				(!this.state.insfailed) ) {
+				this.loadInstance(
+					api, 
+					namespace, 
+					"graph", 
+					undefined
+				)
+			}
+		// }
 
 	}
 
@@ -204,24 +249,65 @@ const Root = class extends Component {
 
 		const {
 			api, 
-			namespace
+			namespace, 
+			typename, 
+			type, 
+			schema
 		} = this.props;		
+
+		// if( (!this.props.type["loading"]) && 
+		// 	(!this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+		// 	// if( typename ) {
+		// 	if( api && namespace && typename ) {
+		// 		this.props.loadType(api, namespace, typename);
+		// 	}
+		// 	// }
+		// }
+
+		// if( (!this.props.schema["loading"]) && 
+		// 	(!this.props.schema["loaded"]) && 
+		// 	(!this.props.schema["failed"]) ) {
+		// 	// if( typename ) {
+		// 	this.props.loadSchema(api, namespace, typename);
+		// 	// }
+		// }
+
+		// var center = undefined;
+		// if( !center ) {
+		// 	if( type && type["entity"] && type["entity"]["_id"] ) {
+		// 		center = type["entity"]["_id"];
+		// 	}
+		// }
+
+		// if( center != this.state.intendedcenter ) {
+		// 	this.setState({
+		// 		intendedcenter: center, 
+		// 		insloading: false, 
+		// 		insloaded: false, 
+		// 		insfailed: false
+		// 	});
+		// }
 
 		/*
 		 * Have to go back to commit cc6304f for this.
 		 * Sun Jul 26 20:54:32 2020 -0700
 		 * Sun Mar 29 16:20:36 2020 -0500
 		 */
-		if( (!this.state.insloading) && 
-			(!this.state.insloaded) && 
-			(!this.state.insfailed) ) {
-			this.loadInstance(
-				api, 
-				namespace, 
-				"graph", 
-				this.state.instanceid
-			)
-		}
+		// if( (!this.props.type["loading"]) && 
+		// 	(this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+			if( (!this.state.insloading) && 
+				(!this.state.insloaded) && 
+				(!this.state.insfailed) ) {
+				this.loadInstance(
+					api, 
+					namespace, 
+					"graph", 
+					undefined
+				)
+			}
+		// }
 
 	}
 
@@ -443,7 +529,7 @@ const Root = class extends Component {
 									id: edge["_id"], 
 									name: edge["_label"], 
 									label: edge["_label"], 
-									link: undefined, 
+									link: undefined,  
 									tree: {
 									}
 								};
@@ -484,8 +570,6 @@ const Root = class extends Component {
 		// 	insloading: false, 
 		// 	insloaded: false, 
 		// 	insfailed: false, 
-		// 	instanceid: instanceid, 
-		// 	instance: false
 		// });
 		// }
 		// if( (!this.state.insloading) && 
@@ -493,11 +577,10 @@ const Root = class extends Component {
 		// 	(!this.state.insfailed) ) {
 		try {
 			this.setState({
+				// intendedcenter: instanceid, 
 				insloading: true, 
 				insloaded: false, 
 				insfailed: false, 
-				instanceid: instanceid, 
-				instance: this.state.instance, 
 				graph: this.state.graph
 			});
 			this.apiClient = new APIClient(
@@ -510,22 +593,21 @@ const Root = class extends Component {
 				instanceid, 
 				(data) => {
 					this.setState({
+						// intendedcenter: instanceid, 
+						// actualcenter: instanceid, 
 						insloading: false, 
 						insloaded: true, 
 						insfailed: false, 
-						instanceid: instanceid, 
-						instance: data, 
-						graph: this.buildGraph(data), 
+						graph: this.buildGraph(data)
 					});
 				});
 
 		} catch {
 			this.setState({
+				// intendedcenter: instanceid, 
 				insloading: false, 
 				insloaded: false, 
 				insfailed: true, 
-				instanceid: undefined, 
-				instance: this.state.instance, 
 				graph: this.state.graph
 			});
 		}
@@ -538,8 +620,6 @@ const Root = class extends Component {
 	// 			insloading: false, 
 	// 			insloaded: false, 
 	// 			insfailed: false, 
-	// 			instanceid: instanceid, 
-	// 			instance: false
 	// 		});
 	// 	}
 	// 	if( (!this.state.inssloading) && 
@@ -549,7 +629,6 @@ const Root = class extends Component {
 	// 			inssloading: true, 
 	// 			inssloaded: false, 
 	// 			inssfailed: false, 
-	// 			instances: false
 	// 		});
 	// 		this.apiClient = new APIClient(
 	// 			api.api.host, 
@@ -565,7 +644,6 @@ const Root = class extends Component {
 	// 					inssloading: false, 
 	// 					inssloaded: true, 
 	// 					inssfailed: false, 
-	// 					instances: data
 	// 				});
 	// 			});
 	// 	}
@@ -642,24 +720,31 @@ const Root = class extends Component {
 	};
 
 	selectItem(id) {
+		// let history = useHistory();
 		if(id) {
-			this.setState({
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false, 
-				instanceid: id.replace('v', ''), 
-				instance: this.state.instance, // undefined
-				selected: id,
-			});
+			var iid = id; // .replace('v', '');
+			if( iid != this.state.instanceid ) {
+				// window.location = "/namespaces/" + "archives" + "/" + id;
+				// history.push("/namespaces/" + "archives" + "/" + id);
+				// navigate("/namespaces/" + "archives" + "/" + id);
+				// this.setState({
+				// 	insloading: false, 
+				// 	insloaded: false, 
+				// 	insfailed: false, 
+				// });
+			}
 		} else {
-			this.setState({
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false, 
-				instanceid: undefined, 
-				instance: this.state.instance, // undefined
-				selected: undefined,
-			});
+			var iid = undefined;
+			if( this.state.instanceid ) {
+				// window.location = "/namespaces/" + "archives";
+				// history.push("/namespaces/" + "archives");
+				// navigate("/namespaces/" + "archives");
+				// this.setState({
+				// 	insloading: false, 
+				// 	insloaded: false, 
+				// 	insfailed: false, 
+				// });
+			}
 		}
 	}
 
@@ -669,7 +754,10 @@ const Root = class extends Component {
 
 		const {
 			api, 
-			namespace
+			namespace, 
+			typename, 
+			type, 
+			schema
 		} = this.props;
 
 		const { classes } = this.props;
@@ -688,10 +776,28 @@ const Root = class extends Component {
 		// var graph = instance;
 		var graph = this.getGraph();
 
+		var highlighted = undefined;
+		var exploded = undefined;
 		var selected = undefined;
-		if( this.state.selected ) {
-			selected = this.state.selected;
-		}
+
+		var pulsed = undefined;
+		var runLayout = true;
+		var zoomFit = true;
+
+		// if( this.state.instanceid && 
+		// 	!this.state.insloading && 
+		// 	this.state.insloaded && 
+		// 	!this.state.insfailed ) {
+
+		// 	highlighted = this.state.instanceid;
+		// 	exploded = this.state.instanceid;
+		// 	selected = this.state.instanceid;
+
+		// 	pulsed = undefined;
+		// 	runLayout = true;
+		// 	zoomFit = true;
+
+		// }
 
 		var hidden = false;
 		var open = true;
@@ -757,7 +863,7 @@ const Root = class extends Component {
 					>
 						<TreeViewItems 
 							// onSelect={item => {
-							// 	this.selectItem( "v" + String( item["_id"] ) );
+							// 	this.selectItem( String( item["_id"] ) );
 							// }}
 							items={treestruc}
 						/>
@@ -791,14 +897,24 @@ const Root = class extends Component {
 							graph={graph}
 							width={graphwidth} 
 							height={graphheight} 
+							highlighted={highlighted} 
+							exploded={exploded} 
 							selected={selected} 
+							pulsed={pulsed} 
+							runLayout={runLayout} 
+							zoomFit={zoomFit} 
 							selectItem={this.selectItem} 
 							contextCommand={this.contextCommand}/>
 						{/* <ThreeDeeGraph
 							graph={graph}
 							width={graphwidth} 
 							height={graphheight} 
+							highlighted={highlighted} 
+							exploded={exploded} 
 							selected={selected} 
+							pulsed={pulsed} 
+							runLayout={runLayout} 
+							zoomFit={zoomFit} 
 							selectItem={this.selectItem} 
 							contextCommand={this.contextCommand}/> */}
 					</Grid>
@@ -837,7 +953,7 @@ function mapStateToProps(state, ownProps) {
 
 	const {
 		api, 
-		// namespace
+		// namespace,
 	} = state;
 
 	var namespace = undefined;

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -611,14 +611,6 @@ class RootInstance extends Component {
 
 		}
 
-		console.log(" !!! ");
-		console.log(" --- ");
-		console.log(schema["entity"]);
-		console.log(instance);
-		console.log(properties);
-		console.log(dependencies);
-		console.log(" --- ");
-
 		return (
 			<>
 			<Container 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -13,14 +13,14 @@ import { withStyles } from '@material-ui/styles';
 
 import {
 	Routes, 
-		BrowserRouter as Router,
-		Switch,
-		Route,
-		Link,
-		useRouteMatch, 
-		useParams, 
-		useNavigate
-	} from "react-router-dom";
+	BrowserRouter as Router,
+	Switch,
+	Route,
+	Link,
+	useRouteMatch, 
+	useParams, 
+	useNavigate
+} from "react-router-dom";
 
 import Typography from '@material-ui/core/Typography';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
@@ -60,6 +60,10 @@ import {
 
 import Graph from './Graph';
 import ThreeDeeGraph from './ThreeDeeGraph';
+
+import history from '../history'
+// import { useNavigate } from "react-router-dom";
+// const navigate = useNavigate();
 
 const styles = theme => ({
 
@@ -154,13 +158,12 @@ const RootInstances = class extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
+			intendedcenter: undefined, 
+			actualcenter: undefined, 
 			insloading: false, 
 			insloaded: false, 
 			insfailed: false, 
-			instanceid: undefined, 
-			instance: undefined, 
-			graph: undefined, 
-			selected: undefined
+			graph: undefined
 		}
 
 		var _this = this;
@@ -173,13 +176,12 @@ const RootInstances = class extends Component {
 	}
 
 	state = {
+		intendedcenter: undefined, 
+		actualcenter: undefined, 
 		insloading: false, 
 		insloaded: false, 
 		insfailed: false, 
-		instanceid: undefined, 
-		instance: undefined, 
-		graph: undefined, 
-		selected: undefined
+		graph: undefined
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -215,27 +217,41 @@ const RootInstances = class extends Component {
 			// }
 		}
 
+		var center = undefined;
+		if( !center ) {
+			if( type && type["entity"] && type["entity"]["_id"] ) {
+				center = type["entity"]["_id"];
+			}
+		}
+
+		if( center != this.state.intendedcenter ) {
+			this.setState({
+				intendedcenter: center, 
+				insloading: false, 
+				insloaded: false, 
+				insfailed: false
+			});
+		}
+
 		/*
 		 * Have to go back to commit cc6304f for this.
 		 * Sun Jul 26 20:54:32 2020 -0700
 		 * Sun Mar 29 16:20:36 2020 -0500
 		 */
-		if( (!this.props.type["loading"]) && 
-			(this.props.type["loaded"]) && 
-			(!this.props.type["failed"]) ) {
-			if( type && type["entity"] && type["entity"]["_id"] ) {
-				if( (!this.state.insloading) && 
-					(!this.state.insloaded) && 
-					(!this.state.insfailed) ) {
-					this.loadInstance(
-						api, 
-						namespace, 
-						"graph", 
-						type["entity"]["_id"] // this.state.instanceid
-					)
-				}
+		// if( (!this.props.type["loading"]) && 
+		// 	(this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+			if( (!this.state.insloading) && 
+				(!this.state.insloaded) && 
+				(!this.state.insfailed) ) {
+				this.loadInstance(
+					api, 
+					namespace, 
+					"graph", 
+					center
+				)
 			}
-		}
+		// }
 
 	}
 
@@ -267,27 +283,41 @@ const RootInstances = class extends Component {
 			// }
 		}
 
+		var center = undefined;
+		if( !center ) {
+			if( type && type["entity"] && type["entity"]["_id"] ) {
+				center = type["entity"]["_id"];
+			}
+		}
+
+		if( center != this.state.intendedcenter ) {
+			this.setState({
+				intendedcenter: center, 
+				insloading: false, 
+				insloaded: false, 
+				insfailed: false
+			});
+		}
+
 		/*
 		 * Have to go back to commit cc6304f for this.
 		 * Sun Jul 26 20:54:32 2020 -0700
 		 * Sun Mar 29 16:20:36 2020 -0500
 		 */
-		if( (!this.props.type["loading"]) && 
-			(this.props.type["loaded"]) && 
-			(!this.props.type["failed"]) ) {
-			if( type && type["entity"] && type["entity"]["_id"] ) {
-				if( (!this.state.insloading) && 
-					(!this.state.insloaded) && 
-					(!this.state.insfailed) ) {
-					this.loadInstance(
-						api, 
-						namespace, 
-						"graph", 
-						type["entity"]["_id"] // this.state.instanceid
-					)
-				}
+		// if( (!this.props.type["loading"]) && 
+		// 	(this.props.type["loaded"]) && 
+		// 	(!this.props.type["failed"]) ) {
+			if( (!this.state.insloading) && 
+				(!this.state.insloaded) && 
+				(!this.state.insfailed) ) {
+				this.loadInstance(
+					api, 
+					namespace, 
+					"graph", 
+					center
+				)
 			}
-		}
+		// }
 
 	}
 
@@ -550,8 +580,6 @@ const RootInstances = class extends Component {
 		// 	insloading: false, 
 		// 	insloaded: false, 
 		// 	insfailed: false, 
-		// 	instanceid: instanceid, 
-		// 	instance: false
 		// });
 		// }
 		// if( (!this.state.insloading) && 
@@ -559,11 +587,10 @@ const RootInstances = class extends Component {
 		// 	(!this.state.insfailed) ) {
 		try {
 			this.setState({
+				intendedcenter: instanceid, 
 				insloading: true, 
 				insloaded: false, 
 				insfailed: false, 
-				instanceid: instanceid, 
-				instance: this.state.instance, 
 				graph: this.state.graph
 			});
 			this.apiClient = new APIClient(
@@ -576,22 +603,21 @@ const RootInstances = class extends Component {
 				instanceid, 
 				(data) => {
 					this.setState({
+						intendedcenter: instanceid, 
+						actualcenter: instanceid, 
 						insloading: false, 
 						insloaded: true, 
 						insfailed: false, 
-						instanceid: instanceid, 
-						instance: data, 
-						graph: this.buildGraph(data), 
+						graph: this.buildGraph(data)
 					});
 				});
 
 		} catch {
 			this.setState({
+				intendedcenter: instanceid, 
 				insloading: false, 
 				insloaded: false, 
 				insfailed: true, 
-				instanceid: undefined, 
-				instance: this.state.instance, 
 				graph: this.state.graph
 			});
 		}
@@ -604,8 +630,6 @@ const RootInstances = class extends Component {
 	// 			insloading: false, 
 	// 			insloaded: false, 
 	// 			insfailed: false, 
-	// 			instanceid: instanceid, 
-	// 			instance: false
 	// 		});
 	// 	}
 	// 	if( (!this.state.inssloading) && 
@@ -615,7 +639,6 @@ const RootInstances = class extends Component {
 	// 			inssloading: true, 
 	// 			inssloaded: false, 
 	// 			inssfailed: false, 
-	// 			instances: false
 	// 		});
 	// 		this.apiClient = new APIClient(
 	// 			api.api.host, 
@@ -631,7 +654,6 @@ const RootInstances = class extends Component {
 	// 					inssloading: false, 
 	// 					inssloaded: true, 
 	// 					inssfailed: false, 
-	// 					instances: data
 	// 				});
 	// 			});
 	// 	}
@@ -708,24 +730,31 @@ const RootInstances = class extends Component {
 	};
 
 	selectItem(id) {
+		// let history = useHistory();
 		if(id) {
-			this.setState({
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false, 
-				instanceid: id.replace('v', ''), 
-				instance: this.state.instance, // undefined
-				selected: id,
-			});
+			var iid = id; // .replace('v', '');
+			if( iid != this.state.instanceid ) {
+				// window.location = "/namespaces/" + "archives" + "/" + id;
+				// history.push("/namespaces/" + "archives" + "/" + id);
+				// navigate("/namespaces/" + "archives" + "/" + id);
+				// this.setState({
+				// 	insloading: false, 
+				// 	insloaded: false, 
+				// 	insfailed: false, 
+				// });
+			}
 		} else {
-			this.setState({
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false, 
-				instanceid: undefined, 
-				instance: this.state.instance, // undefined
-				selected: undefined,
-			});
+			var iid = undefined;
+			if( this.state.instanceid ) {
+				// window.location = "/namespaces/" + "archives";
+				// history.push("/namespaces/" + "archives");
+				// navigate("/namespaces/" + "archives");
+				// this.setState({
+				// 	insloading: false, 
+				// 	insloaded: false, 
+				// 	insfailed: false, 
+				// });
+			}
 		}
 	}
 
@@ -757,11 +786,28 @@ const RootInstances = class extends Component {
 		// var graph = instance;
 		var graph = this.getGraph();
 
-		// var selected = undefined;
-		// if( this.state.selected ) {
-		// 	selected = this.state.selected;
-		// }
+		var highlighted = undefined;
+		var exploded = undefined;
 		var selected = undefined;
+
+		var pulsed = undefined;
+		var runLayout = true;
+		var zoomFit = true;
+
+		if( this.state.instanceid && 
+			!this.state.insloading && 
+			this.state.insloaded && 
+			!this.state.insfailed ) {
+
+			highlighted = this.state.instanceid;
+			exploded = this.state.instanceid;
+			selected = this.state.instanceid;
+
+			pulsed = undefined;
+			runLayout = true;
+			zoomFit = true;
+
+		}
 
 		var hidden = false;
 		var open = true;
@@ -827,7 +873,7 @@ const RootInstances = class extends Component {
 					>
 						<TreeViewItems 
 							// onSelect={item => {
-							// 	this.selectItem( "v" + String( item["_id"] ) );
+							// 	this.selectItem( String( item["_id"] ) );
 							// }}
 							items={treestruc}
 						/>
@@ -864,14 +910,24 @@ const RootInstances = class extends Component {
 							graph={graph}
 							width={graphwidth} 
 							height={graphheight} 
+							highlighted={highlighted} 
+							exploded={exploded} 
 							selected={selected} 
+							pulsed={pulsed} 
+							runLayout={runLayout} 
+							zoomFit={zoomFit} 
 							selectItem={this.selectItem} 
 							contextCommand={this.contextCommand}/>
 						{/* <ThreeDeeGraph
 							graph={graph}
 							width={graphwidth} 
 							height={graphheight} 
+							highlighted={highlighted} 
+							exploded={exploded} 
 							selected={selected} 
+							pulsed={pulsed} 
+							runLayout={runLayout} 
+							zoomFit={zoomFit} 
 							selectItem={this.selectItem} 
 							contextCommand={this.contextCommand}/> */}
 					</Grid>
@@ -915,7 +971,7 @@ function mapStateToProps(state, ownProps) {
 
 	const {
 		api, 
-		// namespace
+		// namespace,
 	} = state;
 
 	var namespace = undefined;


### PR DESCRIPTION
In order to use nav links to move between selected items instead of keeping track of click events via state, we have to move the state of the selected center out of the graph view, and instead keep track of it in parent views and pass it in to the graph. The parent view should simply pass in the intended selected center and let the graph move.