### PR TITLE
Injecting react router navigate into views.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -774,8 +774,8 @@ function withParams(Component) {
 	return props => <Component {...props} params={useParams()} />;
 }
 
-// const Navigation = withParams(withStyles(styles)(AppNavigation));
-// const Notification = withParams(withStyles(styles)(AppNotification));
+// const Navigation = withNavigation(withParams(withStyles(styles)(AppNavigation)));
+// const Notification = withNavigation(withParams(withStyles(styles)(AppNotification)));
 
 const Navigation = withStyles(styles)(AppNavigation);
 const Notification = withStyles(styles)(AppNotification);
@@ -971,4 +971,4 @@ function mapStateToProps(state, ownProps) {
 // export default withStyles(styles)(App);
 // export default connect(mapStateToProps, mapDispatchToProps)(App);
 // export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(App));
-export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(App)));
+export default withNavigation(withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(App))));

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -980,4 +980,4 @@ function withParams(Component) {
 	return props => <Component {...props} params={useParams()} />;
 }
 
-export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root)));
+export default withNavigation(withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Root))));

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -1010,4 +1010,4 @@ function withParams(Component) {
 	return props => <Component {...props} params={useParams()} />;
 }
 
-export default withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances)));
+export default withNavigation(withParams(connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(RootInstances))));


### PR DESCRIPTION
Injecting react router navigate handle into views so that views can direcly navigation state changes on click events.