### PR TITLE
Make sure we can navigate back from an instance.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -750,15 +750,15 @@ const Root = class extends Component {
 			}
 		} else {
 			var iid = undefined;
-			if( this.state.instanceid ) {
-				var namespace = this.props.namespace;
-				this.props.navigate("/namespaces/" + namespace);
-				// this.setState({
-				// 	insloading: false, 
-				// 	insloaded: false, 
-				// 	insfailed: false, 
-				// });
-			}
+			// if( this.state.instanceid ) {
+			var namespace = this.props.namespace;
+			this.props.navigate("/namespaces/" + namespace);
+			// this.setState({
+			// 	insloading: false, 
+			// 	insloaded: false, 
+			// 	insfailed: false, 
+			// });
+			// }
 		}
 	}
 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -762,15 +762,15 @@ const RootInstance = class extends Component {
 			}
 		} else {
 			var iid = undefined;
-			if( this.state.instanceid ) {
-				var namespace = this.props.namespace;
-				this.props.navigate("/namespaces/" + namespace);
-				// this.setState({
-				// 	insloading: false, 
-				// 	insloaded: false, 
-				// 	insfailed: false, 
-				// });
-			}
+			// if( this.state.instanceid ) {
+			var namespace = this.props.namespace;
+			this.props.navigate("/namespaces/" + namespace);
+			// this.setState({
+			// 	insloading: false, 
+			// 	insloaded: false, 
+			// 	insfailed: false, 
+			// });
+			// }
 		}
 	}
 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -760,15 +760,15 @@ const RootInstances = class extends Component {
 			}
 		} else {
 			var iid = undefined;
-			if( this.state.instanceid ) {
-				var namespace = this.props.namespace;
-				this.props.navigate("/namespaces/" + namespace);
-				// this.setState({
-				// 	insloading: false, 
-				// 	insloaded: false, 
-				// 	insfailed: false, 
-				// });
-			}
+			// if( this.state.instanceid ) {
+			var namespace = this.props.namespace;
+			this.props.navigate("/namespaces/" + namespace);
+			// this.setState({
+			// 	insloading: false, 
+			// 	insloaded: false, 
+			// 	insfailed: false, 
+			// });
+			// }
 		}
 	}
 


### PR DESCRIPTION
Make sure we can navigate back from an instance to the root view. This navigational step should be independent of the current instance id state.