### PR TITLE
Keep track of last loaded graph data.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -148,7 +148,8 @@ const Root = class extends Component {
 			insloading: false, 
 			insloaded: false, 
 			insfailed: false, 
-			graph: undefined
+			graph: undefined, 
+			pgraph: undefined
 		}
 
 		var _this = this;
@@ -166,7 +167,8 @@ const Root = class extends Component {
 		insloading: false, 
 		insloaded: false, 
 		insfailed: false, 
-		graph: undefined
+		graph: undefined, 
+		pgraph: undefined
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -591,7 +593,8 @@ const Root = class extends Component {
 				insloading: true, 
 				insloaded: false, 
 				insfailed: false, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 			this.apiClient = new APIClient(
 				api.api.host, 
@@ -608,7 +611,8 @@ const Root = class extends Component {
 						insloading: false, 
 						insloaded: true, 
 						insfailed: false, 
-						graph: this.buildGraph(data)
+						graph: this.buildGraph(data), 
+						pgraph: this.state.graph
 					});
 				});
 
@@ -618,7 +622,8 @@ const Root = class extends Component {
 				insloading: false, 
 				insloaded: false, 
 				insfailed: true, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 		}
 		// }

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -158,7 +158,8 @@ const RootInstance = class extends Component {
 			insloading: false, 
 			insloaded: false, 
 			insfailed: false, 
-			graph: undefined
+			graph: undefined, 
+			pgraph: undefined
 		}
 
 		var _this = this;
@@ -176,7 +177,8 @@ const RootInstance = class extends Component {
 		insloading: false, 
 		insloaded: false, 
 		insfailed: false, 
-		graph: undefined
+		graph: undefined, 
+		pgraph: undefined
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -603,7 +605,8 @@ const RootInstance = class extends Component {
 				insloading: true, 
 				insloaded: false, 
 				insfailed: false, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 			this.apiClient = new APIClient(
 				api.api.host, 
@@ -620,7 +623,8 @@ const RootInstance = class extends Component {
 						insloading: false, 
 						insloaded: true, 
 						insfailed: false, 
-						graph: this.buildGraph(data)
+						graph: this.buildGraph(data), 
+						pgraph: this.state.graph
 					});
 				});
 
@@ -630,7 +634,8 @@ const RootInstance = class extends Component {
 				insloading: false, 
 				insloaded: false, 
 				insfailed: true, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 		}
 		// }

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -158,7 +158,8 @@ const RootInstances = class extends Component {
 			insloading: false, 
 			insloaded: false, 
 			insfailed: false, 
-			graph: undefined
+			graph: undefined, 
+			pgraph: undefined
 		}
 
 		var _this = this;
@@ -176,7 +177,8 @@ const RootInstances = class extends Component {
 		insloading: false, 
 		insloaded: false, 
 		insfailed: false, 
-		graph: undefined
+		graph: undefined, 
+		pgraph: undefined
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -601,7 +603,8 @@ const RootInstances = class extends Component {
 				insloading: true, 
 				insloaded: false, 
 				insfailed: false, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 			this.apiClient = new APIClient(
 				api.api.host, 
@@ -618,7 +621,8 @@ const RootInstances = class extends Component {
 						insloading: false, 
 						insloaded: true, 
 						insfailed: false, 
-						graph: this.buildGraph(data)
+						graph: this.buildGraph(data), 
+						pgraph: this.state.graph
 					});
 				});
 
@@ -628,7 +632,8 @@ const RootInstances = class extends Component {
 				insloading: false, 
 				insloaded: false, 
 				insfailed: true, 
-				graph: this.state.graph
+				graph: this.state.graph, 
+				pgraph: this.state.pgraph
 			});
 		}
 		// }


### PR DESCRIPTION
Keep track of last loaded graph data. This can be used to make the transition from one graph view to another more smooth as we don't completely loose track of where we came from.