### PR TITLE
Display both current and last loaded graph data.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -309,16 +309,67 @@ const Root = class extends Component {
 	}
 
 	getGraph() {
-		var fullgraph = this.state.graph;
-		if( !fullgraph ) {
-			fullgraph = {
-				"@type": "tinker:graph", 
-				"@value": {
-					"vertices": [], 
-					"edges": []
+		var allvertexes = {};
+		var alledges = {};
+		if( this.state.pgraph ) {
+			var vertexes = this.state.pgraph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
 				}
-			};
+			}
+			var edges = this.state.pgraph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
 		}
+		if( this.state.graph ) {
+			var vertexes = this.state.graph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
+				}
+			}
+			var edges = this.state.graph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
+		}
+		var fullgraph = {
+			"@type": "tinker:graph", 
+			"@value": {
+				"vertices": Object.values(allvertexes), // [], 
+				"edges": Object.values(alledges), // []
+			}
+		};
 		return fullgraph;
 	}
 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -321,16 +321,67 @@ const RootInstance = class extends Component {
 	}
 
 	getGraph() {
-		var fullgraph = this.state.graph;
-		if( !fullgraph ) {
-			fullgraph = {
-				"@type": "tinker:graph", 
-				"@value": {
-					"vertices": [], 
-					"edges": []
+		var allvertexes = {};
+		var alledges = {};
+		if( this.state.pgraph ) {
+			var vertexes = this.state.pgraph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
 				}
-			};
+			}
+			var edges = this.state.pgraph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
 		}
+		if( this.state.graph ) {
+			var vertexes = this.state.graph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
+				}
+			}
+			var edges = this.state.graph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
+		}
+		var fullgraph = {
+			"@type": "tinker:graph", 
+			"@value": {
+				"vertices": Object.values(allvertexes), // [], 
+				"edges": Object.values(alledges), // []
+			}
+		};
 		return fullgraph;
 	}
 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -319,16 +319,67 @@ const RootInstances = class extends Component {
 	}
 
 	getGraph() {
-		var fullgraph = this.state.graph;
-		if( !fullgraph ) {
-			fullgraph = {
-				"@type": "tinker:graph", 
-				"@value": {
-					"vertices": [], 
-					"edges": []
+		var allvertexes = {};
+		var alledges = {};
+		if( this.state.pgraph ) {
+			var vertexes = this.state.pgraph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
 				}
-			};
+			}
+			var edges = this.state.pgraph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
 		}
+		if( this.state.graph ) {
+			var vertexes = this.state.graph["@value"]["vertices"];
+			if( vertexes ) {
+				for( var i=0; i<vertexes.length; i++ ) {
+					var vertex = vertexes[i]["@value"];
+					if( (vertex) && (vertex["_id"]) ) {
+						allvertexes[vertex["_id"]] = {
+							"@type": "g:Vertex", 
+							"@value": vertex
+						};
+					}
+				}
+			}
+			var edges = this.state.graph["@value"]["edges"];
+			if( edges ) {
+				for( var i=0; i<edges.length; i++ ) {
+					var edge = edges[i]["@value"];
+					if( (edge) && (edge["_id"]) ) {
+						alledges[edge["_id"]] = {
+							"@type": "g:Edge", 
+							"@value": edge
+						};
+					}
+				}
+			}
+		}
+		var fullgraph = {
+			"@type": "tinker:graph", 
+			"@value": {
+				"vertices": Object.values(allvertexes), // [], 
+				"edges": Object.values(alledges), // []
+			}
+		};
 		return fullgraph;
 	}
 


### PR DESCRIPTION
Display both current and last loaded graph data. This can be used to make the transition from one graph view to another more smooth as we don't completely loose track of where we came from.