### PR TITLE
Graphs with no edges should still show vertices.

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -516,9 +516,9 @@ class Graph extends Component {
 		 * Fix this by loading vertices and edges at once via the graph API call, instead
 		 * of loading vertices and edges separate.
 		 */
-		if( edges.length <= 0 ) {
-			return [];
-		}
+		// if( edges.length <= 0 ) {
+		// 	return [];
+		// }
 
 		if( vertexes ) {
 			for( var i=0; i<vertexes.length; i++ ) {

--- a/src/components/ThreeDeeGraph.js
+++ b/src/components/ThreeDeeGraph.js
@@ -279,16 +279,16 @@ class ThreeDeeGraph extends Component {
 		 * Fix this by loading vertices and edges at once via the graph API call, instead
 		 * of loading vertices and edges separate.
 		 */
-		if( edges.length <= 0 ) {
-			return {
-				"nodes":[
-					
-				],
-				"links":[
-					
-				]
-			};
-		}
+		// if( edges.length <= 0 ) {
+		// 	return {
+		// 		"nodes":[
+		// 			
+		// 		],
+		// 		"links":[
+		// 			
+		// 		]
+		// 	};
+		// }
 
 		var nodes = [];
 		var links = [];


### PR DESCRIPTION
Graphs with no edges should still show vertices. In the past graphs that lacked edges were not shown, as graphs would not show until the both vertices and edges fully loaded. Graphs are now loaded with one REST call, which means we can remove this restriction, and edge less graphs can show.