### PR TITLE
Fix for nav tree ordering.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -491,7 +491,7 @@ const Root = class extends Component {
 							var source = vs[_outV];
 							var target = vs[_inV];
 							if( !(edge["_label"] in treestruc[source["_label"]]["tree"][source["_id"]]["tree"]) ) {
-								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]] = {
+								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]] = {
 									id: edge["_id"], 
 									name: edge["_label"], 
 									label: edge["_label"], 
@@ -500,7 +500,7 @@ const Root = class extends Component {
 									}
 								};
 							}
-							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]]["tree"][target["_id"]] = {
+							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]]["tree"][target["_id"]] = {
 								id: target["_id"], 
 								name: target["properties"]["_name"], 
 								label: target["properties"]["_name"], // + "." + target["_label"], 

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -573,7 +573,7 @@ const RootInstance = class extends Component {
 							var source = vs[_outV];
 							var target = vs[_inV];
 							if( !(edge["_label"] in treestruc[source["_label"]]["tree"][source["_id"]]["tree"]) ) {
-								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]] = {
+								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]] = {
 									id: edge["_id"], 
 									name: edge["_label"], 
 									label: edge["_label"], 
@@ -582,7 +582,7 @@ const RootInstance = class extends Component {
 									}
 								};
 							}
-							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]]["tree"][target["_id"]] = {
+							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]]["tree"][target["_id"]] = {
 								id: target["_id"], 
 								name: target["properties"]["_name"], 
 								label: target["properties"]["_name"], // + "." + target["_label"], 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -571,7 +571,7 @@ const RootInstances = class extends Component {
 							var source = vs[_outV];
 							var target = vs[_inV];
 							if( !(edge["_label"] in treestruc[source["_label"]]["tree"][source["_id"]]["tree"]) ) {
-								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]] = {
+								treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]] = {
 									id: edge["_id"], 
 									name: edge["_label"], 
 									label: edge["_label"], 
@@ -580,7 +580,7 @@ const RootInstances = class extends Component {
 									}
 								};
 							}
-							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_id"]]["tree"][target["_id"]] = {
+							treestruc[source["_label"]]["tree"][source["_id"]]["tree"][edge["_label"]]["tree"][target["_id"]] = {
 								id: target["_id"], 
 								name: target["properties"]["_name"], 
 								label: target["properties"]["_name"], // + "." + target["_label"], 


### PR DESCRIPTION
Fix for nav tree ordering where the nav tree creates a new ordering node for each item to list in the tree, instead of grouping all items with the same order under one ordering node.