### PR TITLE
Renaming graph loading status variables.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -145,9 +145,9 @@ const Root = class extends Component {
 		this.state = {
 			// intendedcenter: undefined, 
 			// actualcenter: undefined, 
-			insloading: false, 
-			insloaded: false, 
-			insfailed: false, 
+			grfloading: false, 
+			grfloaded: false, 
+			grffailed: false, 
 			graph: undefined, 
 			pgraph: undefined
 		}
@@ -164,9 +164,9 @@ const Root = class extends Component {
 	state = {
 		// intendedcenter: undefined, 
 		// actualcenter: undefined, 
-		insloading: false, 
-		insloaded: false, 
-		insfailed: false, 
+		grfloading: false, 
+		grfloaded: false, 
+		grffailed: false, 
 		graph: undefined, 
 		pgraph: undefined
 	};
@@ -192,9 +192,9 @@ const Root = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -224,9 +224,9 @@ const Root = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -532,21 +532,21 @@ const Root = class extends Component {
 	loadInstance(api, namespace, typename, instanceid) {
 		// if( this.state.instanceid != instanceid ) {
 		// this.setState({
-		// 	insloading: false, 
-		// 	insloaded: false, 
-		// 	insfailed: false, 
+		// 	grfloading: false, 
+		// 	grfloaded: false, 
+		// 	grffailed: false, 
 		// });
 		// }
-		// if( (!this.state.insloading) && 
-		// 	(!this.state.insloaded) && 
-		// 	(!this.state.insfailed) ) {
+		// if( (!this.state.grfloading) && 
+		// 	(!this.state.grfloaded) && 
+		// 	(!this.state.grffailed) ) {
 		try {
 			this.setState({
 				// intendedcenter: instanceid, 
 				// actualcenter: this.state.actualcenter, 
-				insloading: true, 
-				insloaded: false, 
-				insfailed: false, 
+				grfloading: true, 
+				grfloaded: false, 
+				grffailed: false, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -562,9 +562,9 @@ const Root = class extends Component {
 					this.setState({
 						// intendedcenter: instanceid, 
 						// actualcenter: instanceid, 
-						insloading: false, 
-						insloaded: true, 
-						insfailed: false, 
+						grfloading: false, 
+						grfloaded: true, 
+						grffailed: false, 
 						graph: this.buildGraph(data), 
 						pgraph: this.state.graph
 					});
@@ -574,9 +574,9 @@ const Root = class extends Component {
 			this.setState({
 				// intendedcenter: instanceid, 
 				// actualcenter: this.state.actualcenter, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: true, 
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: true, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -603,9 +603,9 @@ const Root = class extends Component {
 					var typename = node["_label"];
 					this.props.navigate("/namespaces/" + namespace + "/" + typename + "/" + id);
 					// this.setState({
-					// 	insloading: false, 
-					// 	insloaded: false, 
-					// 	insfailed: false, 
+					// 	grfloading: false, 
+					// 	grfloaded: false, 
+					// 	grffailed: false, 
 					// });
 				}
 			}
@@ -615,9 +615,9 @@ const Root = class extends Component {
 			var namespace = this.props.namespace;
 			this.props.navigate("/namespaces/" + namespace);
 			// this.setState({
-			// 	insloading: false, 
-			// 	insloaded: false, 
-			// 	insfailed: false, 
+			// 	grfloading: false, 
+			// 	grfloaded: false, 
+			// 	grffailed: false, 
 			// });
 			// }
 		}

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -155,9 +155,9 @@ const RootInstance = class extends Component {
 		this.state = {
 			intendedcenter: undefined, 
 			actualcenter: undefined, 
-			insloading: false, 
-			insloaded: false, 
-			insfailed: false, 
+			grfloading: false, 
+			grfloaded: false, 
+			grffailed: false, 
 			graph: undefined, 
 			pgraph: undefined
 		}
@@ -174,9 +174,9 @@ const RootInstance = class extends Component {
 	state = {
 		intendedcenter: undefined, 
 		actualcenter: undefined, 
-		insloading: false, 
-		insloaded: false, 
-		insfailed: false, 
+		grfloading: false, 
+		grfloaded: false, 
+		grffailed: false, 
 		graph: undefined, 
 		pgraph: undefined
 	};
@@ -225,9 +225,9 @@ const RootInstance = class extends Component {
 		if( center != this.state.intendedcenter ) {
 			this.setState({
 				intendedcenter: center, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: false
 			});
 		}
 
@@ -239,9 +239,9 @@ const RootInstance = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -292,9 +292,9 @@ const RootInstance = class extends Component {
 		if( center != this.state.intendedcenter ) {
 			this.setState({
 				intendedcenter: center, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: false
 			});
 		}
 
@@ -306,9 +306,9 @@ const RootInstance = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -614,21 +614,21 @@ const RootInstance = class extends Component {
 	loadInstance(api, namespace, typename, instanceid) {
 		// if( this.state.instanceid != instanceid ) {
 		// this.setState({
-		// 	insloading: false, 
-		// 	insloaded: false, 
-		// 	insfailed: false, 
+		// 	grfloading: false, 
+		// 	grfloaded: false, 
+		// 	grffailed: false, 
 		// });
 		// }
-		// if( (!this.state.insloading) && 
-		// 	(!this.state.insloaded) && 
-		// 	(!this.state.insfailed) ) {
+		// if( (!this.state.grfloading) && 
+		// 	(!this.state.grfloaded) && 
+		// 	(!this.state.grffailed) ) {
 		try {
 			this.setState({
 				intendedcenter: instanceid, 
 				actualcenter: this.state.actualcenter, 
-				insloading: true, 
-				insloaded: false, 
-				insfailed: false, 
+				grfloading: true, 
+				grfloaded: false, 
+				grffailed: false, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -644,9 +644,9 @@ const RootInstance = class extends Component {
 					this.setState({
 						intendedcenter: instanceid, 
 						actualcenter: instanceid, 
-						insloading: false, 
-						insloaded: true, 
-						insfailed: false, 
+						grfloading: false, 
+						grfloaded: true, 
+						grffailed: false, 
 						graph: this.buildGraph(data), 
 						pgraph: this.state.graph
 					});
@@ -656,9 +656,9 @@ const RootInstance = class extends Component {
 			this.setState({
 				intendedcenter: instanceid, 
 				actualcenter: this.state.actualcenter, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: true, 
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: true, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -685,9 +685,9 @@ const RootInstance = class extends Component {
 					var typename = node["_label"];
 					this.props.navigate("/namespaces/" + namespace + "/" + typename + "/" + id);
 					// this.setState({
-					// 	insloading: false, 
-					// 	insloaded: false, 
-					// 	insfailed: false, 
+					// 	grfloading: false, 
+					// 	grfloaded: false, 
+					// 	grffailed: false, 
 					// });
 				}
 			}
@@ -697,9 +697,9 @@ const RootInstance = class extends Component {
 			var namespace = this.props.namespace;
 			this.props.navigate("/namespaces/" + namespace);
 			// this.setState({
-			// 	insloading: false, 
-			// 	insloaded: false, 
-			// 	insfailed: false, 
+			// 	grfloading: false, 
+			// 	grfloaded: false, 
+			// 	grffailed: false, 
 			// });
 			// }
 		}

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -155,9 +155,9 @@ const RootInstances = class extends Component {
 		this.state = {
 			intendedcenter: undefined, 
 			actualcenter: undefined, 
-			insloading: false, 
-			insloaded: false, 
-			insfailed: false, 
+			grfloading: false, 
+			grfloaded: false, 
+			grffailed: false, 
 			graph: undefined, 
 			pgraph: undefined
 		}
@@ -174,9 +174,9 @@ const RootInstances = class extends Component {
 	state = {
 		intendedcenter: undefined, 
 		actualcenter: undefined, 
-		insloading: false, 
-		insloaded: false, 
-		insfailed: false, 
+		grfloading: false, 
+		grfloaded: false, 
+		grffailed: false, 
 		graph: undefined, 
 		pgraph: undefined
 	};
@@ -224,9 +224,9 @@ const RootInstances = class extends Component {
 		if( center != this.state.intendedcenter ) {
 			this.setState({
 				intendedcenter: center, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: false
 			});
 		}
 
@@ -238,9 +238,9 @@ const RootInstances = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -290,9 +290,9 @@ const RootInstances = class extends Component {
 		if( center != this.state.intendedcenter ) {
 			this.setState({
 				intendedcenter: center, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: false
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: false
 			});
 		}
 
@@ -304,9 +304,9 @@ const RootInstances = class extends Component {
 		// if( (!this.props.type["loading"]) && 
 		// 	(this.props.type["loaded"]) && 
 		// 	(!this.props.type["failed"]) ) {
-			if( (!this.state.insloading) && 
-				(!this.state.insloaded) && 
-				(!this.state.insfailed) ) {
+			if( (!this.state.grfloading) && 
+				(!this.state.grfloaded) && 
+				(!this.state.grffailed) ) {
 				this.loadInstance(
 					api, 
 					namespace, 
@@ -612,21 +612,21 @@ const RootInstances = class extends Component {
 	loadInstance(api, namespace, typename, instanceid) {
 		// if( this.state.instanceid != instanceid ) {
 		// this.setState({
-		// 	insloading: false, 
-		// 	insloaded: false, 
-		// 	insfailed: false, 
+		// 	grfloading: false, 
+		// 	grfloaded: false, 
+		// 	grffailed: false, 
 		// });
 		// }
-		// if( (!this.state.insloading) && 
-		// 	(!this.state.insloaded) && 
-		// 	(!this.state.insfailed) ) {
+		// if( (!this.state.grfloading) && 
+		// 	(!this.state.grfloaded) && 
+		// 	(!this.state.grffailed) ) {
 		try {
 			this.setState({
 				intendedcenter: instanceid, 
 				actualcenter: this.state.actualcenter, 
-				insloading: true, 
-				insloaded: false, 
-				insfailed: false, 
+				grfloading: true, 
+				grfloaded: false, 
+				grffailed: false, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -642,9 +642,9 @@ const RootInstances = class extends Component {
 					this.setState({
 						intendedcenter: instanceid, 
 						actualcenter: instanceid, 
-						insloading: false, 
-						insloaded: true, 
-						insfailed: false, 
+						grfloading: false, 
+						grfloaded: true, 
+						grffailed: false, 
 						graph: this.buildGraph(data), 
 						pgraph: this.state.graph
 					});
@@ -654,9 +654,9 @@ const RootInstances = class extends Component {
 			this.setState({
 				intendedcenter: instanceid, 
 				actualcenter: this.state.actualcenter, 
-				insloading: false, 
-				insloaded: false, 
-				insfailed: true, 
+				grfloading: false, 
+				grfloaded: false, 
+				grffailed: true, 
 				graph: this.state.graph, 
 				pgraph: this.state.pgraph
 			});
@@ -683,9 +683,9 @@ const RootInstances = class extends Component {
 					var typename = node["_label"];
 					this.props.navigate("/namespaces/" + namespace + "/" + typename + "/" + id);
 					// this.setState({
-					// 	insloading: false, 
-					// 	insloaded: false, 
-					// 	insfailed: false, 
+					// 	grfloading: false, 
+					// 	grfloaded: false, 
+					// 	grffailed: false, 
 					// });
 				}
 			}
@@ -695,9 +695,9 @@ const RootInstances = class extends Component {
 			var namespace = this.props.namespace;
 			this.props.navigate("/namespaces/" + namespace);
 			// this.setState({
-			// 	insloading: false, 
-			// 	insloaded: false, 
-			// 	insfailed: false, 
+			// 	grfloading: false, 
+			// 	grfloaded: false, 
+			// 	grffailed: false, 
 			// });
 			// }
 		}


### PR DESCRIPTION
Renaming graph loading status variables to not clash with instance loading status varible names. This is probably not needed, but I wrote it up and have been testing with it so it stays.