### PR TITLE
Working MUI 6 Lists.

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -283,6 +283,7 @@ export default {
 	Header, 
 	Sidebar, 
 	Breadcrumb, 
+	List, 
 	Main, 
 	Side
 };


### PR DESCRIPTION
Working MUI 6 Lists. These were working earlier in MUI 4, but seeminly not in MUI 6 so they were disabled eariler.