### PR TITLE
Attempt to use as much space as possible for Graph View.

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -332,6 +332,7 @@ class Graph extends Component {
 
 		var _this = this;
 
+		this.divRef = React.createRef();
 		this.graphRef = React.createRef();
 
 		this.selectItem = this.selectItem.bind(this);
@@ -675,7 +676,7 @@ class Graph extends Component {
 		// }
 
 		if( !setheight ) {
-			setheight = 640;
+			setheight = "calc(100vh - 40px - 64px)"; // 640;
 		}
 
 		// if( !minheight ) {
@@ -741,21 +742,12 @@ class Graph extends Component {
 		var runLayout = this.props.runLayout;
 		var zoomFit = this.props.zoomFit;
 
-		// console.log("???? GRAPH ???? ");
-		// // console.log();
-		// console.log(selected);
-		// console.log(highlighted);
-		// console.log(exploded);
-		// console.log(pulsed);
-		// console.log(runLayout);
-		// console.log(zoomFit);
-
 		return (
 			<>
-			{/* <Container 
-				// className={classes.graphContainer} 
-				className="graphContainer" 
-				maxWidth="xl"> */}
+			<div 
+				ref={this.divRef} 
+				style={{width: "100%"}}
+			>
 			<CustomCytoscapeComponent
 				ref={this.graphRef}
 				className="graph"
@@ -783,7 +775,7 @@ class Graph extends Component {
 					// backgroundColor: "white"
 				}}
 			/>
-			{/* </Container> */}
+			</div>
 			</>
 		);
 	}

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -73,12 +73,14 @@ const Root = class extends Component {
 			grfloaded: false, 
 			grffailed: false, 
 			graph: undefined, 
-			pgraph: undefined
+			pgraph: undefined, 
+			mainWidth: 0, 
+			mainHeight: 0
 		}
 
 		var _this = this;
 
-		this.gridRef = React.createRef();
+		this.mainRef = React.createRef();
 
 		this.selectItem = this.selectItem.bind(this);
 		this.contextCommand = this.contextCommand.bind(this);
@@ -92,7 +94,9 @@ const Root = class extends Component {
 		grfloaded: false, 
 		grffailed: false, 
 		graph: undefined, 
-		pgraph: undefined
+		pgraph: undefined, 
+		mainWidth: 0, 
+		mainHeight: 0
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -107,6 +111,15 @@ const Root = class extends Component {
 			type, 
 			schema
 		} = this.props;
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		/*
 		 * Have to go back to commit cc6304f for this.
@@ -139,6 +152,15 @@ const Root = class extends Component {
 			type, 
 			schema
 		} = this.props;
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		/*
 		 * Have to go back to commit cc6304f for this.
@@ -588,18 +610,12 @@ const Root = class extends Component {
 		// var treestruc = this.getTreeData(api, namespace, graph);
 
 		var graphwidth = 640;
-		var graphheight = 640;
-		if( this.gridRef.current ) {
-			graphwidth = this.gridRef.current.offsetWidth;
-			graphheight = this.gridRef.current.offsetHeight;
+		var graphheight = "calc(100vh - 40px - 64px)"; // 640;
+		if( this.state.mainWidth > 0 ) {
+			graphwidth = this.state.mainWidth
 		}
-
-		if( graphwidth > 1280 ) {
-			graphwidth = 1280;
-		}
-
-		if( graphheight > 640 ) {
-			graphheight = 640;
+		if( this.state.mainHeight > 0 ) {
+			graphheight = this.state.mainHeight
 		}
 
 		return (
@@ -633,6 +649,13 @@ const Root = class extends Component {
 				</Breadcrumbs>
 			</Layout.Breadcrumb>
 			<Layout.Main>
+				<div 
+					ref={this.mainRef} 
+					style={{
+						width: "100%", 
+						height: "100%"
+					}}
+				>
 				<Graph 
 					graph={graph} 
 					width={graphwidth} 
@@ -659,6 +682,7 @@ const Root = class extends Component {
 					selectItem={this.selectItem} 
 					contextCommand={this.contextCommand}
 				/> */}
+				</div>
 			</Layout.Main>
 			<Layout.Side>
 				<Graph

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -86,12 +86,14 @@ const RootInstance = class extends Component {
 			grfloaded: false, 
 			grffailed: false, 
 			graph: undefined, 
-			pgraph: undefined
+			pgraph: undefined, 
+			mainWidth: 0, 
+			mainHeight: 0
 		}
 
 		var _this = this;
 
-		this.gridRef = React.createRef();
+		this.mainRef = React.createRef();
 
 		this.selectItem = this.selectItem.bind(this);
 		this.contextCommand = this.contextCommand.bind(this);
@@ -105,7 +107,9 @@ const RootInstance = class extends Component {
 		grfloaded: false, 
 		grffailed: false, 
 		graph: undefined, 
-		pgraph: undefined
+		pgraph: undefined, 
+		mainWidth: 0, 
+		mainHeight: 0
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -121,6 +125,15 @@ const RootInstance = class extends Component {
 			type, 
 			schema
 		} = this.props;
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		if( (!this.props.type["loading"]) && 
 			(!this.props.type["loaded"]) && 
@@ -190,6 +203,15 @@ const RootInstance = class extends Component {
 			type, 
 			schema
 		} = this.props;	
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		if( (!this.props.type["loading"]) && 
 			(!this.props.type["loaded"]) && 
@@ -681,18 +703,12 @@ const RootInstance = class extends Component {
 		// var treestruc = this.getTreeData(api, namespace, graph);
 
 		var graphwidth = 640;
-		var graphheight = 640;
-		if( this.gridRef.current ) {
-			graphwidth = this.gridRef.current.offsetWidth;
-			graphheight = this.gridRef.current.offsetHeight;
+		var graphheight = "calc(100vh - 40px - 64px)"; // 640;
+		if( this.state.mainWidth > 0 ) {
+			graphwidth = this.state.mainWidth
 		}
-
-		if( graphwidth > 1280 ) {
-			graphwidth = 1280;
-		}
-
-		if( graphheight > 640 ) {
-			graphheight = 640;
+		if( this.state.mainHeight > 0 ) {
+			graphheight = this.state.mainHeight
 		}
 
 		return (
@@ -729,6 +745,13 @@ const RootInstance = class extends Component {
 				</Breadcrumbs>
 			</Layout.Breadcrumb>
 			<Layout.Main>
+				<div 
+					ref={this.mainRef} 
+					style={{
+						width: "100%", 
+						height: "100%"
+					}}
+				>
 				<Graph 
 					graph={graph} 
 					width={graphwidth} 
@@ -755,6 +778,7 @@ const RootInstance = class extends Component {
 					selectItem={this.selectItem} 
 					contextCommand={this.contextCommand}
 				/> */}
+				</div>
 			</Layout.Main>
 			<Layout.Side>
 				<Graph

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -83,12 +83,14 @@ const RootInstances = class extends Component {
 			grfloaded: false, 
 			grffailed: false, 
 			graph: undefined, 
-			pgraph: undefined
+			pgraph: undefined, 
+			mainWidth: 0, 
+			mainHeight: 0
 		}
 
 		var _this = this;
 
-		this.gridRef = React.createRef();
+		this.mainRef = React.createRef();
 
 		this.selectItem = this.selectItem.bind(this);
 		this.contextCommand = this.contextCommand.bind(this);
@@ -102,7 +104,9 @@ const RootInstances = class extends Component {
 		grfloaded: false, 
 		grffailed: false, 
 		graph: undefined, 
-		pgraph: undefined
+		pgraph: undefined, 
+		mainWidth: 0, 
+		mainHeight: 0
 	};
 
 	// componentWillUpdate(nextProps, nextState) {
@@ -117,6 +121,15 @@ const RootInstances = class extends Component {
 			type, 
 			schema
 		} = this.props;
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		if( (!this.props.type["loading"]) && 
 			(!this.props.type["loaded"]) && 
@@ -185,6 +198,15 @@ const RootInstances = class extends Component {
 			type, 
 			schema
 		} = this.props;	
+
+		if( this.mainRef && this.mainRef.current ) {
+			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
+				this.setState({
+					mainWidth: this.mainRef.current.offsetWidth, 
+					mainHeight: this.mainRef.current.offsetHeight
+				});
+			}
+		}
 
 		if( (!this.props.type["loading"]) && 
 			(!this.props.type["loaded"]) && 
@@ -674,18 +696,12 @@ const RootInstances = class extends Component {
 		// var treestruc = this.getTreeData(api, namespace, graph);
 
 		var graphwidth = 640;
-		var graphheight = 640;
-		if( this.gridRef.current ) {
-			graphwidth = this.gridRef.current.offsetWidth;
-			graphheight = this.gridRef.current.offsetHeight;
+		var graphheight = "calc(100vh - 40px - 64px)"; // 640;
+		if( this.state.mainWidth > 0 ) {
+			graphwidth = this.state.mainWidth
 		}
-
-		if( graphwidth > 1280 ) {
-			graphwidth = 1280;
-		}
-
-		if( graphheight > 640 ) {
-			graphheight = 640;
+		if( this.state.mainHeight > 0 ) {
+			graphheight = this.state.mainHeight
 		}
 
 		return (
@@ -719,6 +735,13 @@ const RootInstances = class extends Component {
 				</Breadcrumbs>
 			</Layout.Breadcrumb>
 			<Layout.Main>
+				<div 
+					ref={this.mainRef} 
+					style={{
+						width: "100%", 
+						height: "100%"
+					}}
+				>
 				<Graph 
 					graph={graph} 
 					width={graphwidth} 
@@ -745,6 +768,7 @@ const RootInstances = class extends Component {
 					selectItem={this.selectItem} 
 					contextCommand={this.contextCommand}
 				/> */}
+				</div>
 			</Layout.Main>
 			<Layout.Side>
 				<Graph


### PR DESCRIPTION
Attempt to use as much space as possible for Graph View by setting the size of the Graph view to use all available space within the node to render in. This seems to be best done by setting the width and height to match a known ref node within the view.