### PR TITLE
Stop Graph view from resetting when clicking outside selected.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -555,18 +555,19 @@ const Root = class extends Component {
 					// });
 				}
 			}
-		} else {
-			var iid = undefined;
-			// if( this.state.instanceid ) {
-			var namespace = this.props.namespace;
-			this.props.navigate("/namespaces/" + namespace);
-			// this.setState({
-			// 	grfloading: false, 
-			// 	grfloaded: false, 
-			// 	grffailed: false, 
-			// });
-			// }
-		}
+		} 
+		// else {
+		// 	var iid = undefined;
+		// 	// if( this.state.instanceid ) {
+		// 	var namespace = this.props.namespace;
+		// 	this.props.navigate("/namespaces/" + namespace);
+		// 	// this.setState({
+		// 	// 	grfloading: false, 
+		// 	// 	grfloaded: false, 
+		// 	// 	grffailed: false, 
+		// 	// });
+		// 	// }
+		// }
 	}
 
 	render() {

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -202,7 +202,7 @@ const RootInstance = class extends Component {
 			instanceid, 
 			type, 
 			schema
-		} = this.props;	
+		} = this.props;
 
 		if( this.mainRef && this.mainRef.current ) {
 			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
@@ -640,18 +640,19 @@ const RootInstance = class extends Component {
 					// });
 				}
 			}
-		} else {
-			var iid = undefined;
-			// if( this.state.instanceid ) {
-			var namespace = this.props.namespace;
-			this.props.navigate("/namespaces/" + namespace);
-			// this.setState({
-			// 	grfloading: false, 
-			// 	grfloaded: false, 
-			// 	grffailed: false, 
-			// });
-			// }
-		}
+		} 
+		// else {
+		// 	var iid = undefined;
+		// 	// if( this.state.instanceid ) {
+		// 	var namespace = this.props.namespace;
+		// 	this.props.navigate("/namespaces/" + namespace);
+		// 	// this.setState({
+		// 	// 	grfloading: false, 
+		// 	// 	grfloaded: false, 
+		// 	// 	grffailed: false, 
+		// 	// });
+		// 	// }
+		// }
 	}
 
 	render() {

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -197,7 +197,7 @@ const RootInstances = class extends Component {
 			typename, 
 			type, 
 			schema
-		} = this.props;	
+		} = this.props;
 
 		if( this.mainRef && this.mainRef.current ) {
 			if( this.state.mainWidth != this.mainRef.current.offsetWidth ) {
@@ -635,18 +635,19 @@ const RootInstances = class extends Component {
 					// });
 				}
 			}
-		} else {
-			var iid = undefined;
-			// if( this.state.instanceid ) {
-			var namespace = this.props.namespace;
-			this.props.navigate("/namespaces/" + namespace);
-			// this.setState({
-			// 	grfloading: false, 
-			// 	grfloaded: false, 
-			// 	grffailed: false, 
-			// });
-			// }
-		}
+		} 
+		// else {
+		// 	var iid = undefined;
+		// 	// if( this.state.instanceid ) {
+		// 	var namespace = this.props.namespace;
+		// 	this.props.navigate("/namespaces/" + namespace);
+		// 	// this.setState({
+		// 	// 	grfloading: false, 
+		// 	// 	grfloaded: false, 
+		// 	// 	grffailed: false, 
+		// 	// });
+		// 	// }
+		// }
 	}
 
 	render() {


### PR DESCRIPTION
Stop Graph view from resetting when clicking outside selected element as this too easily resets a zoomed view and forces the user to again find the right path and navigate down, or use the back navigation button. Instead, let the user explicitly reset the Graph view by clicking the home button.