### PR TITLE
Show both Sidebar menu icon and Navbar back button.

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -726,25 +726,15 @@ const Root = class extends Component {
 						types={types} 
 					>
 						<IconButton 
-							// color="inherit" 
-							// aria-label="open drawer" 
-							// onClick={toggleDrawerOpen} 
 							onClick={() => toggleDrawerOpen()} 
-							// edge="start" 
-							// variant="highlight" 
 							color="neutral" 
 							variant="plain" 
-							sx={[
-								{
-									marginRight: 5, 
-									color: 'rgb(97, 97, 97)'
-								},
-								// open && { display: 'none' }
-							]}
+							sx={{
+								marginRight: '10px !important', 
+								color: 'rgb(97, 97, 97)'
+							}}
 						>
 							<MenuIcon 
-								// color="neutral" 
-								// variant="plain" 
 								sx={{
 									color: 'rgb(97, 97, 97)'
 								}}

--- a/src/components/RootInstance.js
+++ b/src/components/RootInstance.js
@@ -813,6 +813,21 @@ const RootInstance = class extends Component {
 						namespace={namespace} 
 						types={types} 
 					>
+						<IconButton 
+							onClick={() => toggleDrawerOpen()} 
+							color="neutral" 
+							variant="plain" 
+							sx={{
+								marginRight: '10px !important', 
+								color: 'rgb(97, 97, 97)'
+							}}
+						>
+							<MenuIcon 
+								sx={{
+									color: 'rgb(97, 97, 97)'
+								}}
+							/>
+						</IconButton>
 						<BackNavButton></BackNavButton>
 						<Button 
 							component="a" 

--- a/src/components/RootInstances.js
+++ b/src/components/RootInstances.js
@@ -806,6 +806,21 @@ const RootInstances = class extends Component {
 						namespace={namespace} 
 						types={types} 
 					>
+						<IconButton 
+							onClick={() => toggleDrawerOpen()} 
+							color="neutral" 
+							variant="plain" 
+							sx={{
+								marginRight: '10px !important', 
+								color: 'rgb(97, 97, 97)'
+							}}
+						>
+							<MenuIcon 
+								sx={{
+									color: 'rgb(97, 97, 97)'
+								}}
+							/>
+						</IconButton>
 						<BackNavButton></BackNavButton>
 						<Button 
 							component="a" 


### PR DESCRIPTION
Show both Sidebar menu icon and Navbar back button. This lets us use the Sidebar on detail pages.